### PR TITLE
Maven Surfire reports: Upload artifacts + print simple report to github summary

### DIFF
--- a/.github/workflows/build-jar-maven.yml
+++ b/.github/workflows/build-jar-maven.yml
@@ -55,6 +55,12 @@ jobs:
           path: libs
           retention-days: 4
           overwrite: true
+      - name: Upload Surefire Reports
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: "**/target/surefire-reports/"
 
   post-fail-to-slack-if-non-pull-request:
     needs: maven-build

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -58,10 +58,10 @@ jobs:
             done
             errorOrFailureReportCount=${#errorOrFailureReports[@]}
             if [ "$errorOrFailureReportCount" -gt "10" ]; then
-              echo ":rotating_light: Printing 10 of $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
-              for i in {0..count}
+              echo ":rotating_light: Printing first 10 of $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
+              for i in {0..10}
               do
-                cat "${errorOrFailureReports[i]}" >> $GITHUB_STEP_SUMMARY
+                cat "${errorOrFailureReports[$i]}" >> $GITHUB_STEP_SUMMARY
               done
             else 
               echo ":rotating_light: Found $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -47,7 +47,7 @@ jobs:
         if: failure()
         run: |
           readarray -d '' reports < <(find . -wholename "*/target/surefire-reports/*.txt" -print0)
-          if [ ${#errors[@]} -eq 0 ]; then
+          if [ ${#reports[@]} -eq 0 ]; then
             echo "No surefire reports found"
           else
             errorOrFailureReports=()

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -58,13 +58,13 @@ jobs:
             done
             errorOrFailureReportCount=${#errorOrFailureReports[@]}
             if [ "$errorOrFailureReportCount" -gt "10" ]; then
-              echo "Printing 10 of $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
+              echo ":rotating_light: Printing 10 of $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
               for i in {0..count}
               do
                 cat "${errorOrFailureReports[$i]}" >> $GITHUB_STEP_SUMMARY
               done
             else 
-              echo "Found $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
+              echo ":rotating_light: Found $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
               for report in "${errorOrFailureReports[@]}"; do
                 cat "$report" >> $GITHUB_STEP_SUMMARY
               done

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -61,7 +61,7 @@ jobs:
               echo ":rotating_light: Printing 10 of $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
               for i in {0..count}
               do
-                cat "${errorOrFailureReports[$i]}" >> $GITHUB_STEP_SUMMARY
+                cat "${errorOrFailureReports[i]}" >> $GITHUB_STEP_SUMMARY
               done
             else 
               echo ":rotating_light: Found $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -47,10 +47,23 @@ jobs:
         if: failure()
         run: |
           readarray -d '' reports < <(find . -wholename "*/target/surefire-reports/*.txt" -print0)
-          for report in "${reports[@]}"; do
-            #echo "Current item: $report"
-            if ! grep -q 'Failures: 0, Errors: 0' $report; then
-              echo $report
-              cat $report >> $GITHUB_STEP_SUMMARY
-            fi
-          done
+          if [ ${#errors[@]} -eq 0 ]; then
+            echo "No surefire reports found"
+          else
+            errorOrFailureReports=()
+            for report in "${reports[@]}"; do
+              if ! grep -q 'Failures: 0, Errors: 0' $report; then
+                errorOrFailureReports+=($report)
+              fi
+            done
+          
+            echo "Found ${#errorOrFailureReports[@]} unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
+            maxSummary=10
+            availableSummary=${#errorOrFailureReports[@]}
+            count=$(( maxSummary < availableSummary ? maxSummary : availableSummary ))
+            
+            for i in {0..count}
+            do
+              cat "${errorOrFailureReports[$i]}" >> $GITHUB_STEP_SUMMARY
+            done
+          fi

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -70,3 +70,9 @@ jobs:
               done
             fi
           fi
+      - name: Upload Surefire Reports
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: "**/target/surefire-reports/"

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -43,3 +43,14 @@ jobs:
       - name: Verify
         run: |
           mvn ${{ inputs.commands }}
+      - name: Print error reports
+        if: failure()
+        run: |
+          readarray -d '' reports < <(find . -wholename "*/target/surefire-reports/*.txt" -print0)
+          for report in "${reports[@]}"; do
+            #echo "Current item: $report"
+            if ! grep -q 'Failures: 0, Errors: 0' $report; then
+              echo $report
+              cat $report >> $GITHUB_STEP_SUMMARY
+            fi
+          done

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -57,15 +57,15 @@ jobs:
               fi
             done
             errorOrFailureReportCount=${#errorOrFailureReports[@]}
-            echo "Found $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
             if [ "$errorOrFailureReportCount" -gt "10" ]; then
-              echo "Printing 10 first below." >> $GITHUB_STEP_SUMMARY
+              echo "Printing 10 of $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
               for i in {0..count}
               do
                 cat "${errorOrFailureReports[$i]}" >> $GITHUB_STEP_SUMMARY
               done
             else 
-              for report in "${reports[@]}"; do
+              echo "Found $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
+              for report in "${errorOrFailureReports[@]}"; do
                 cat "$report" >> $GITHUB_STEP_SUMMARY
               done
             fi

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -56,14 +56,17 @@ jobs:
                 errorOrFailureReports+=($report)
               fi
             done
-          
-            echo "Found ${#errorOrFailureReports[@]} unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
-            maxSummary=10
-            availableSummary=${#errorOrFailureReports[@]}
-            count=$(( maxSummary < availableSummary ? maxSummary : availableSummary ))
-            
-            for i in {0..count}
-            do
-              cat "${errorOrFailureReports[$i]}" >> $GITHUB_STEP_SUMMARY
-            done
+            errorOrFailureReportCount=${#errorOrFailureReports[@]}
+            echo "Found $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
+            if [ "$errorOrFailureReportCount" -gt "10" ]; then
+              echo "Printing 10 first below." >> $GITHUB_STEP_SUMMARY
+              for i in {0..count}
+              do
+                cat "${errorOrFailureReports[$i]}" >> $GITHUB_STEP_SUMMARY
+              done
+            else 
+              for report in "${reports[@]}"; do
+                cat "$report" >> $GITHUB_STEP_SUMMARY
+              done
+            fi
           fi

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -66,6 +66,12 @@ jobs:
           git tag -a ${REL_PREFIX}${CURRENT_VERSION} HEAD -m "Release $CURRENT_VERSION" 
           git push --tags
           echo "Release commit has been tagged"
+      - name: Upload Surefire Reports
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: "**/target/surefire-reports/"
 
   post-failure-to-slack:
     needs: maven-release

--- a/.github/workflows/validate-jar-maven.yml
+++ b/.github/workflows/validate-jar-maven.yml
@@ -80,11 +80,11 @@ jobs:
         run: |
           readarray -d '' reports < <(find . -wholename "*/target/surefire-reports/*.txt" -print0)
           for report in "${reports[@]}"; do
-          #echo "Current item: $report"
-          if ! grep -q 'Failures: 0, Errors: 0' $report; then
-            echo $report
-            cat $report >> $GITHUB_STEP_SUMMARY
-          fi
+            #echo "Current item: $report"
+            if ! grep -q 'Failures: 0, Errors: 0' $report; then
+              echo $report
+              cat $report >> $GITHUB_STEP_SUMMARY
+            fi
           done
       - name: Ready for upload
         if: success() && inputs.upload-artifact == 'true'

--- a/.github/workflows/validate-jar-maven.yml
+++ b/.github/workflows/validate-jar-maven.yml
@@ -75,6 +75,17 @@ jobs:
         run: |
           mvn -B clean verify -P${{inputs.build-profiles}}
           echo "Validating maven build with profile(s): ${{inputs.build-profiles}}" >> $GITHUB_STEP_SUMMARY
+      - name: Print error reports
+        if: failure()
+        run: |
+          readarray -d '' reports < <(find . -wholename "*/target/surefire-reports/*.txt" -print0)
+          for report in "${reports[@]}"; do
+          #echo "Current item: $report"
+          if ! grep -q 'Failures: 0, Errors: 0' $report; then
+            echo $report
+            cat $report >> $GITHUB_STEP_SUMMARY
+          fi
+          done
       - name: Ready for upload
         if: success() && inputs.upload-artifact == 'true'
         run: |

--- a/.github/workflows/validate-jar-maven.yml
+++ b/.github/workflows/validate-jar-maven.yml
@@ -79,13 +79,35 @@ jobs:
         if: failure()
         run: |
           readarray -d '' reports < <(find . -wholename "*/target/surefire-reports/*.txt" -print0)
-          for report in "${reports[@]}"; do
-            #echo "Current item: $report"
-            if ! grep -q 'Failures: 0, Errors: 0' $report; then
-              echo $report
-              cat $report >> $GITHUB_STEP_SUMMARY
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "No surefire reports found"
+          else
+            errorOrFailureReports=()
+            for report in "${reports[@]}"; do
+              if ! grep -q 'Failures: 0, Errors: 0' $report; then
+                errorOrFailureReports+=($report)
+              fi
+            done
+            errorOrFailureReportCount=${#errorOrFailureReports[@]}
+            if [ "$errorOrFailureReportCount" -gt "10" ]; then
+              echo ":rotating_light: Printing first 10 of $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
+              for i in {0..10}
+              do
+                cat "${errorOrFailureReports[$i]}" >> $GITHUB_STEP_SUMMARY
+              done
+            else 
+              echo ":rotating_light: Found $errorOrFailureReportCount unit test files with failure(s) and/or error(s)." >> $GITHUB_STEP_SUMMARY
+              for report in "${errorOrFailureReports[@]}"; do
+                cat "$report" >> $GITHUB_STEP_SUMMARY
+              done
             fi
-          done
+          fi
+      - name: Upload Surefire Reports
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: "**/target/surefire-reports/"
       - name: Ready for upload
         if: success() && inputs.upload-artifact == 'true'
         run: |
@@ -99,6 +121,7 @@ jobs:
           path: libs
           retention-days: 4
           overwrite: true
+
 
   post-to-slack-if-failure:
     needs: validate-maven-build


### PR DESCRIPTION
Maven builds, on failure:

 * upload surfire reports
 * print report txt files in branch builds to github summary
   * max 10 report files

Example: https://github.com/entur/netex-utils/actions/runs/17827359380