### PR TITLE
Use Gradle build with --no-daemon option in CI workflows

### DIFF
--- a/.github/workflows/build-jar-gradle.yml
+++ b/.github/workflows/build-jar-gradle.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle Wrapper
-        run: ./gradlew clean build
+        run: ./gradlew clean build --no-daemon
         env:
           MAVEN_USERNAME: ${{ secrets.ARTIFACTORY_AUTH_USER }}
           MAVEN_PASSWORD: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}

--- a/.github/workflows/validate-jar-gradle.yml
+++ b/.github/workflows/validate-jar-gradle.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle Wrapper
-        run: ./gradlew clean build
+        run: ./gradlew clean build --no-daemon
         env:
           MAVEN_USERNAME: ${{ secrets.ARTIFACTORY_AUTH_USER }}
           MAVEN_PASSWORD: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}


### PR DESCRIPTION
The Gradle daemon is designed to speed up builds by keeping a JVM process alive between builds. In CI environments like GitHub Actions, each job runs in a fresh environment, so the daemon process does not persist between jobs.

Why: by disabling the daemon (--no-daemon) avoids unnecessary background processes, reducing memory usage and makes build run faster