### PR TITLE
Inline jobs in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: cd-${{ inputs.environment }}-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   tf-plan:
     name: Terraform Plan

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,10 @@ on:
 jobs:
   tf-plan:
     name: Terraform Plan
-    uses: ./.github/workflows/terraform-plan.yml
+    uses: entur/gha-terraform/.github/workflows/plan.yml@v2
+    concurrency:
+      group: terraform-plan-${{ inputs.environment }}-${{ github.repository }}
+      cancel-in-progress: true
     with:
       environment: ${{ inputs.environment }}
     secrets: inherit
@@ -27,7 +30,10 @@ jobs:
   tf-apply:
     name: Terraform Apply
     needs: [tf-plan]
-    uses: ./.github/workflows/terraform-apply.yml
+    uses: entur/gha-terraform/.github/workflows/apply.yml@v2
+    concurrency:
+      group: terraform-apply-${{ inputs.environment }}-${{ github.repository }}
+      cancel-in-progress: false
     with:
       environment: ${{ inputs.environment }}
       has_changes: ${{ needs.tf-plan.outputs.has_changes }}
@@ -38,9 +44,12 @@ jobs:
     needs: [tf-apply]
     # Terraform apply is skipped on empty plan. This if ensures that job is run even if previous step is skipped
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    uses: ./.github/workflows/helm-deploy.yml
+    uses: entur/gha-helm/.github/workflows/deploy.yml@v1
+    concurrency:
+      group: helm-deploy-${{ inputs.environment }}-${{ github.repository }}
+      cancel-in-progress: false
     with:
       environment: ${{ inputs.environment }}
       image: ${{ inputs.image }}
-      channel-id: ${{ inputs.channel-id }}
+      slack_channel_id: ${{ inputs.channel-id }}
     secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,9 +24,6 @@ jobs:
   tf-plan:
     name: Terraform Plan
     uses: entur/gha-terraform/.github/workflows/plan.yml@v2
-    concurrency:
-      group: terraform-plan-${{ inputs.environment }}-${{ github.repository }}
-      cancel-in-progress: true
     with:
       environment: ${{ inputs.environment }}
     secrets: inherit
@@ -35,9 +32,6 @@ jobs:
     name: Terraform Apply
     needs: [tf-plan]
     uses: entur/gha-terraform/.github/workflows/apply.yml@v2
-    concurrency:
-      group: terraform-apply-${{ inputs.environment }}-${{ github.repository }}
-      cancel-in-progress: false
     with:
       environment: ${{ inputs.environment }}
       has_changes: ${{ needs.tf-plan.outputs.has_changes }}
@@ -49,9 +43,6 @@ jobs:
     # Terraform apply is skipped on empty plan. This if ensures that job is run even if previous step is skipped
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     uses: entur/gha-helm/.github/workflows/deploy.yml@v1
-    concurrency:
-      group: helm-deploy-${{ inputs.environment }}-${{ github.repository }}
-      cancel-in-progress: false
     with:
       environment: ${{ inputs.environment }}
       image: ${{ inputs.image }}

--- a/.github/workflows/helm-deploy.yml
+++ b/.github/workflows/helm-deploy.yml
@@ -17,7 +17,7 @@ on:
         type: string
 
 concurrency:
-  group: cd-deploy-${{ inputs.environment }}-${{ github.repository }}
+  group: helm-deploy-${{ inputs.environment }}-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
When using relative paths in reusable workflows, it points to a relative path in the caller repo instead of this repo. To work around this issue we inline the workflows.

## Example from abt-offline-control when using relative paths
```
[Invalid workflow file: .github/workflows/cd.yml#L61](https://github.com/entur/abt-offline-control/actions/runs/25483009272/workflow)
error parsing called workflow
".github/workflows/cd.yml"
-> "entur/abt-gha-public/.github/workflows/cd.yml@v1.8" (source tag with sha:c274af0bbe3c39108447fe6c304a0d496a285627)
--> "./.github/workflows/helm-deploy.yml"
```