### PR TITLE
Move concurrency to job level for deploy serialization

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,10 +26,6 @@ on:
         type: boolean
         default: true
 
-concurrency:
-  group: cd-${{ inputs.environment }}-${{ github.repository }}
-  cancel-in-progress: false
-
 jobs:
   git-diff-url:
     name: Git Diff URL
@@ -90,6 +86,9 @@ jobs:
   tf-apply:
     name: Terraform Apply
     needs: [tf-plan]
+    concurrency:
+      group: cd-deploy-${{ inputs.environment }}-${{ github.repository }}
+      cancel-in-progress: false
     uses: entur/gha-terraform/.github/workflows/apply.yml@v2
     with:
       environment: ${{ inputs.environment }}
@@ -101,6 +100,9 @@ jobs:
     needs: [tf-apply]
     # Terraform apply is skipped on empty plan. This if ensures that job is run even if previous step is skipped
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    concurrency:
+      group: cd-deploy-${{ inputs.environment }}-${{ github.repository }}
+      cancel-in-progress: false
     uses: entur/gha-helm/.github/workflows/deploy.yml@v1
     with:
       environment: ${{ inputs.environment }}


### PR DESCRIPTION
## Summary
- Bytter fra workflow-level til job-level concurrency i `cd.yml`. `tf-plan`, `git-diff-url` og `notify-diff` kjører nå fritt parallelt på tvers av runs.
- `tf-apply` og `deploy` deler `cd-deploy-${env}-${repo}` med `cancel-in-progress: false`, så hele apply→deploy-kjeden serialiseres mot miljøet og pågående deploys aldri blir avbrutt.
- Konsekvens: når en eldre run venter på approval i `tf-apply` og en nyere kommer i samme gruppe, blir den eldre pending auto-kansellert av GitHub — slik at man slipper å manuelt rydde gamle godkjenninger.

## Avveiing
GitHub tillater bare 1 pending per concurrency-gruppe, så det er fortsatt maks 1 approval ventende av gangen (men alltid den ferskeste). Ekte "ubegrenset approvals" à la Harness krever å splitte approval-gaten ut og lage egne `*-deploy`-environments uten reviewers i hvert repo — utenfor scope her.

## Test plan
- [ ] Push to en service som bruker `cd.yml@<denne refen>`, verifiser at deploy til dev fortsatt går gjennom (inkl. environment approval).
- [ ] Push to commits raskt etter hverandre mot samme miljø; verifiser at eldre pending `tf-apply` blir auto-kansellert og nyeste overlever.
- [ ] Mens en `tf-apply` eller `deploy` faktisk kjører, push en ny commit; verifiser at pågående jobb ikke blir kansellert og den nye venter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)