### PR TITLE
Link branch name to PR in auto-merge failure Slack message

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -165,5 +165,5 @@ jobs:
     uses: entur/gha-slack/.github/workflows/post.yml@v2
     with:
       channel_id: ${{ inputs.channel-id }}
-      message: "⚫ Automerge of dependabot PR failed. This is most likely due to branch being behind HEAD on main, and will be resolved by dependabot. ${{ github.event.pull_request.head.ref }}"
+      message: "⚫ Automerge of dependabot PR failed. <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.head.ref }}>"
     secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,7 +73,7 @@ jobs:
     uses: entur/gha-slack/.github/workflows/post.yml@v2
     with:
       channel_id: ${{ inputs.channel-id }}
-      message: "New <${{ needs.git-diff-url.outputs.compare_url }}|changelog> for ${{ github.event.repository.name }} ${{ needs.git-diff-url.outputs.short_sha }} in ${{ inputs.environment }}"
+      message: "📋 New <${{ needs.git-diff-url.outputs.compare_url }}|changelog> for ${{ github.event.repository.name }} ${{ needs.git-diff-url.outputs.short_sha }} in ${{ inputs.environment }}"
     secrets: inherit
 
   tf-plan:

--- a/.github/workflows/notify-changelog.yml
+++ b/.github/workflows/notify-changelog.yml
@@ -59,5 +59,5 @@ jobs:
     uses: entur/gha-slack/.github/workflows/post.yml@v2
     with:
       channel_id: ${{ inputs.channel-id }}
-      message: "New <${{ needs.git-diff-url.outputs.compare_url }}|changelog> for ${{ github.event.repository.name }} ${{ needs.git-diff-url.outputs.short_sha }} in ${{ inputs.environment }}"
+      message: "📋 New <${{ needs.git-diff-url.outputs.compare_url }}|changelog> for ${{ github.event.repository.name }} ${{ needs.git-diff-url.outputs.short_sha }} in ${{ inputs.environment }}"
     secrets: inherit

--- a/.github/workflows/trigger-missed-dependabot-deploy.yml
+++ b/.github/workflows/trigger-missed-dependabot-deploy.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   check-and-trigger:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: write

--- a/.github/workflows/trigger-missed-dependabot-deploy.yml
+++ b/.github/workflows/trigger-missed-dependabot-deploy.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: false
+      channel-id:
+        description: "Slack channel-id to post notification to"
+        required: false
+        type: string
+        default: ${{ vars.channel_id || 'NO_ID'}}
 
 jobs:
   check-and-trigger:
@@ -27,8 +32,12 @@ jobs:
     permissions:
       contents: read
       actions: write
+    outputs:
+      dispatched: ${{ steps.inspect.outputs.dispatched }}
+      sha: ${{ steps.inspect.outputs.sha }}
     steps:
       - name: Inspect latest commit and dispatch if needed
+        id: inspect
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -41,9 +50,11 @@ jobs:
           SHA=$(gh api "repos/${REPO}/commits/${REF}" --jq '.sha')
           AUTHOR=$(gh api "repos/${REPO}/commits/${SHA}" --jq '.author.login // ""')
           echo "Latest commit on ${REF}: ${SHA} (author: ${AUTHOR:-unknown})" >> $GITHUB_STEP_SUMMARY
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
 
           if [ "$AUTHOR" != "dependabot[bot]" ]; then
             echo "Latest commit is not from dependabot; nothing to do." >> $GITHUB_STEP_SUMMARY
+            echo "dispatched=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -52,6 +63,7 @@ jobs:
 
           if [ "$RUNS" -gt 0 ]; then
             echo "Target workflow has already run for ${SHA}; nothing to do." >> $GITHUB_STEP_SUMMARY
+            echo "dispatched=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -62,8 +74,28 @@ jobs:
 
           if [ "$DRY_RUN" = "true" ]; then
             echo "Dry-run: would dispatch \`${TARGET_WORKFLOW}\` on \`${REF}\`." >> $GITHUB_STEP_SUMMARY
+            echo "dispatched=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           gh workflow run "${TARGET_WORKFLOW}" --repo "${REPO}" --ref "${REF}"
           echo "Dispatched \`${TARGET_WORKFLOW}\` on \`${REF}\`." >> $GITHUB_STEP_SUMMARY
+          echo "dispatched=true" >> $GITHUB_OUTPUT
+
+  post-to-slack-if-dispatched:
+    needs: check-and-trigger
+    if: success() && needs.check-and-trigger.outputs.dispatched == 'true' && inputs.channel-id != 'NO_ID'
+    uses: entur/gha-slack/.github/workflows/post.yml@v2
+    with:
+      channel_id: ${{ inputs.channel-id }}
+      message: "🔵 ${{ github.repository }} - Triggered missed dependabot deploy on `${{ inputs.target-ref }}` (${{ needs.check-and-trigger.outputs.sha }})"
+    secrets: inherit
+
+  post-fail-to-slack-if-fail:
+    needs: check-and-trigger
+    if: failure() && inputs.channel-id != 'NO_ID'
+    uses: entur/gha-slack/.github/workflows/post.yml@v2
+    with:
+      channel_id: ${{ inputs.channel-id }}
+      message: "⚫ Trigger missed dependabot deploy failed on `${{ inputs.target-ref }}`"
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Slimmer ned feilmeldingen for mislykket auto-merge i `auto-merge.yml`
- Branchnavnet (f.eks. `dependabot/gradle/gradle-wrapper-9.5.1`) vises nå som en blå lenke til selve PR-en via Slack sin `<url|tekst>`-syntaks

## Test plan
- [ ] Trigge en mislykket auto-merge og verifisere at Slack-meldingen viser branchnavnet som klikkbar lenke til PR-en