### PR TITLE
Send Slack notification on actual merge (closed event), not on queue

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -132,29 +132,34 @@ jobs:
           else
             echo "- Non-dependabot PR; no merge would have been attempted." >> $GITHUB_STEP_SUMMARY
           fi
-      - name: Do merge
-        id: merge-it
+      - name: Queue auto-merge
         if: >
           inputs.dry-run != true &&
-          steps.decide.outputs.should-merge == 'true'
+          steps.decide.outputs.should-merge == 'true' &&
+          github.event.action != 'closed'
         env:
           GH_TOKEN: ${{ github.token }}
           REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          # Check BEFORE merging: if auto-merge is already queued (e.g. because
-          # Dependabot rebased the PR after another PR was merged to main), we
-          # skip the Slack notification to avoid a cascade of duplicate messages.
-          ALREADY_QUEUED=$(gh pr view "$REF" --json autoMergeRequest --jq '.autoMergeRequest != null')
           # --auto defers the merge until all required status checks pass
           # and the branch is up to date; relies on branch protection being
-          # configured to require checks.
+          # configured to require checks. Calling it again on rebase (synchronize)
+          # is idempotent — no notification is sent here; that happens on 'closed'.
           gh pr merge --auto --squash "$REF"
-          if [ "$ALREADY_QUEUED" = "false" ]; then
-            echo "message=Automatically merged dependabot branch $REF" >> $GITHUB_OUTPUT
-            echo "Queued auto-merge for $REF (first time — Slack notification will be sent)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "Auto-merge already queued for $REF — skipping duplicate Slack notification" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "Queued auto-merge for $REF" >> $GITHUB_STEP_SUMMARY
+
+      - name: Report merged
+        id: merge-it
+        if: >
+          inputs.dry-run != true &&
+          steps.decide.outputs.should-merge == 'true' &&
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true
+        env:
+          REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          echo "message=Automatically merged dependabot branch $REF" >> $GITHUB_OUTPUT
+          echo "PR $REF was merged — Slack notification will be sent" >> $GITHUB_STEP_SUMMARY
 
   post-to-slack-if-merged:
     needs: auto-merge

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -141,13 +141,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          echo "Attempting to auto-merge $REF" >> $GITHUB_STEP_SUMMARY
+          # Check BEFORE merging: if auto-merge is already queued (e.g. because
+          # Dependabot rebased the PR after another PR was merged to main), we
+          # skip the Slack notification to avoid a cascade of duplicate messages.
+          ALREADY_QUEUED=$(gh pr view "$REF" --json autoMergeRequest --jq '.autoMergeRequest != null')
           # --auto defers the merge until all required status checks pass
           # and the branch is up to date; relies on branch protection being
           # configured to require checks.
           gh pr merge --auto --squash "$REF"
-          echo "message=Automatically merged dependabot branch $REF" >> $GITHUB_OUTPUT
-          echo "Successfully queued auto-merge for $REF" >> $GITHUB_STEP_SUMMARY
+          if [ "$ALREADY_QUEUED" = "false" ]; then
+            echo "message=Automatically merged dependabot branch $REF" >> $GITHUB_OUTPUT
+            echo "Queued auto-merge for $REF (first time — Slack notification will be sent)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Auto-merge already queued for $REF — skipping duplicate Slack notification" >> $GITHUB_STEP_SUMMARY
+          fi
 
   post-to-slack-if-merged:
     needs: auto-merge


### PR DESCRIPTION
## Problem

`gh pr merge --auto` only *queues* the merge — the PR is not merged immediately. But the notification fired every time the workflow ran (opened + every rebase/synchronize).

When branch protection requires up-to-date branches, each merge causes all other open dependabot PRs to rebase. This fires a `synchronize` event per PR, which re-runs the workflow and sends another notification. With N open PRs: **N + (N-1) + ... + 1 = N*(N+1)/2 messages** instead of N.

## Fix

Split into two steps:

- **Queue auto-merge** (opened/synchronize): calls `gh pr merge --auto --squash`, no notification. Idempotent — safe to call on every rebase.
- **Report merged** (closed + merged == true): sets the output that triggers the Slack notification. Fires exactly once, when the PR is actually merged.

Consumer repos must add `- closed` to their `pull_request` types (done in separate PRs for each repo).