### PR TITLE
Drop unnecessary contents/issues write permissions from auto-merge job

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -51,8 +51,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
-      contents: write
-      issues: write
     outputs:
       deploy-message: ${{ steps.merge-it.outputs.message }}
     steps:


### PR DESCRIPTION
Removes `contents: write` and `issues: write` from the auto-merge job — these permissions are not needed. Was accidentally left out when PR #34 was squash-merged.