### PR TITLE
Add contents: read permission to auto-merge job

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
+      contents: read
     outputs:
       deploy-message: ${{ steps.merge-it.outputs.message }}
     steps:


### PR DESCRIPTION
The nested call to `gha-slack` requires `contents: read`. Without it callers get: _'nested job is requesting contents: read, but is only allowed contents: none'_.