### PR TITLE
Remove broken merged-Slack notification, list deployed PRs in dispatch message

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -52,8 +52,6 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    outputs:
-      deploy-message: ${{ steps.merge-it.outputs.message }}
     steps:
       - uses: actions/checkout@v4
       - name: Dependabot metadata
@@ -146,29 +144,6 @@ jobs:
           # is idempotent — no notification is sent here; that happens on 'closed'.
           gh pr merge --auto --squash "$REF"
           echo "Queued auto-merge for $REF" >> $GITHUB_STEP_SUMMARY
-
-      - name: Report merged
-        id: merge-it
-        if: >
-          inputs.dry-run != true &&
-          steps.decide.outputs.should-merge == 'true' &&
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
-        env:
-          REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          echo "message=Automatically merged dependabot branch $REF" >> $GITHUB_OUTPUT
-          echo "PR $REF was merged — Slack notification will be sent" >> $GITHUB_STEP_SUMMARY
-
-  post-to-slack-if-merged:
-    needs: auto-merge
-    # The contains bit is important to prevent empty messages in case aut-merge step was skipped (not failed)
-    if: success() && contains(needs.auto-merge.outputs.deploy-message,'Automatically merged') && inputs.channel-id != 'NO_ID'
-    uses: entur/gha-slack/.github/workflows/post.yml@v2
-    with:
-      channel_id: ${{ inputs.channel-id }}
-      message: "🔵 ${{ github.repository }} - ${{ needs.auto-merge.outputs.deploy-message }}"
-    secrets: inherit
 
   post-fail-to-slack-if-fail:
     needs: auto-merge

--- a/.github/workflows/trigger-missed-dependabot-deploy.yml
+++ b/.github/workflows/trigger-missed-dependabot-deploy.yml
@@ -35,6 +35,7 @@ jobs:
     outputs:
       dispatched: ${{ steps.inspect.outputs.dispatched }}
       sha: ${{ steps.inspect.outputs.sha }}
+      commits: ${{ steps.inspect.outputs.commits }}
     steps:
       - name: Inspect latest commit and dispatch if needed
         id: inspect
@@ -67,6 +68,43 @@ jobs:
             exit 0
           fi
 
+          # Bound the deployed range by the head_sha of the last successful target-workflow run
+          # on this ref. Falls back to the head commit alone when there is no prior run.
+          LAST_DEPLOYED_SHA=$(gh api "repos/${REPO}/actions/workflows/${TARGET_WORKFLOW}/runs?per_page=1&status=success&branch=${REF}" --jq '.workflow_runs[0].head_sha // ""')
+
+          if [ -n "$LAST_DEPLOYED_SHA" ] && [ "$LAST_DEPLOYED_SHA" != "$SHA" ]; then
+            COMMITS=$(gh api "repos/${REPO}/compare/${LAST_DEPLOYED_SHA}...${SHA}" --jq '
+              [.commits[]
+               | select(.author.login == "dependabot[bot]")
+               | .commit.message
+               | split("\n")[0]
+               | if test("\\(#[0-9]+\\)$") then
+                   capture("(?<subject>.+) \\(#(?<pr>[0-9]+)\\)$")
+                   | "* \(.subject) (<https://github.com/'"${REPO}"'/pull/\(.pr)|#\(.pr)>)"
+                 else
+                   "* \(.)"
+                 end
+              ] | join("\n")
+            ')
+          else
+            COMMITS=$(gh api "repos/${REPO}/commits/${SHA}" --jq '
+              .commit.message
+              | split("\n")[0]
+              | if test("\\(#[0-9]+\\)$") then
+                  capture("(?<subject>.+) \\(#(?<pr>[0-9]+)\\)$")
+                  | "* \(.subject) (<https://github.com/'"${REPO}"'/pull/\(.pr)|#\(.pr)>)"
+                else
+                  "* \(.)"
+                end
+            ')
+          fi
+
+          {
+            echo "commits<<COMMITS_EOF"
+            echo "$COMMITS"
+            echo "COMMITS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
           echo "## Missed deploy detected" >> $GITHUB_STEP_SUMMARY
           echo "- Ref: \`${REF}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Commit: \`${SHA}\`" >> $GITHUB_STEP_SUMMARY
@@ -88,7 +126,9 @@ jobs:
     uses: entur/gha-slack/.github/workflows/post.yml@v2
     with:
       channel_id: ${{ inputs.channel-id }}
-      message: "🔵 ${{ github.repository }} - Triggered missed dependabot deploy on ${{ inputs.target-ref }} (${{ needs.check-and-trigger.outputs.sha }})"
+      message: |
+        🔵 ${{ github.repository }} - Triggered dependabot deploy on ${{ inputs.target-ref }}
+        ${{ needs.check-and-trigger.outputs.commits }}
     secrets: inherit
 
   post-fail-to-slack-if-fail:


### PR DESCRIPTION
## Summary
- **auto-merge.yml:** Drop \`post-to-slack-if-merged\` (and the \`Report merged\` step + \`deploy-message\` output that fed it). The job fired on the dependabot PR's \`closed\` event, but Dependabot's \`GITHUB_TOKEN\` cannot start downstream workflows after merge, so the notification never actually arrived. \`post-fail-to-slack-if-fail\` is unaffected.
- **trigger-missed-dependabot-deploy.yml:** Slack message now lists the dependabot commits being deployed, with each PR number as a mrkdwn link. The range is bounded by the \`head_sha\` of the last successful run of the target workflow on the ref (falls back to the head commit if there is none).

## Example new message
\`\`\`
🔵 entur/abt-backoffice - Triggered dependabot deploy on main
* Bump sass from 1.97.2 to 1.99.0 (#3604)
\`\`\`
…where \`#3604\` is a link to the PR.

## Test plan
- [ ] Consume the updated \`trigger-missed-dependabot-deploy.yml\` from a downstream repo and verify the Slack message format with a real auto-merged dependabot PR
- [ ] Verify the auto-merge workflow still queues merges and that the failure-Slack job still works
- [ ] Verify nothing references the removed \`deploy-message\` output