### PR TITLE
Fix: only include dependabot commits since last non-bot commit in Slack message

### DIFF
--- a/.github/workflows/trigger-missed-dependabot-deploy.yml
+++ b/.github/workflows/trigger-missed-dependabot-deploy.yml
@@ -74,8 +74,20 @@ jobs:
 
           if [ -n "$LAST_DEPLOYED_SHA" ] && [ "$LAST_DEPLOYED_SHA" != "$SHA" ]; then
             COMMITS=$(gh api "repos/${REPO}/compare/${LAST_DEPLOYED_SHA}...${SHA}" --jq '
-              [.commits[]
-               | select(.author.login == "dependabot[bot]")
+              [.commits
+               | reverse
+               | reduce .[] as $c (
+                   {done: false, result: []};
+                   if .done then .
+                   elif ($c.author.login == "dependabot[bot]") then
+                     .result += [$c]
+                   else
+                     {done: true, result: .result}
+                   end
+                 )
+               | .result
+               | reverse
+               | .[]
                | .commit.message
                | split("\n")[0]
                | if test("\\(#[0-9]+\\)$") then


### PR DESCRIPTION
## Problem

The Slack notification from `trigger-missed-dependabot-deploy.yml` was listing every dependabot commit between the last deployed SHA and HEAD, regardless of any non-dependabot commits in between. This caused a very long and misleading commit list — the assumption is that non-dependabot commits have already been deployed, so only the dependabot commits *after* the most recent non-bot commit are relevant.

## Fix

Changed the GROQ/jq query to walk commits newest-first and stop at the first commit whose author is not `dependabot[bot]`. The resulting list is then reversed back to chronological order for the Slack message.

Before:
```jq
[.commits[] | select(.author.login == "dependabot[bot]") | ...]
```

After:
```jq
[.commits | reverse | reduce .[] as $c ({done: false, result: []}; ...) | .result | reverse | .[] | ...]
```