### PR TITLE
Add check-last-workflow-run workflow

### DIFF
--- a/.github/workflows/check-last-workflow-run.yml
+++ b/.github/workflows/check-last-workflow-run.yml
@@ -1,0 +1,128 @@
+name: Check Last Workflow Run
+# Checks whether a workflow has had a successful run within the configured
+# number of days. Useful for alerting when a release workflow has not fired
+# recently, indicating a library may be overdue for a release.
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        description: "Workflow filename to check (e.g. release-main.yml)."
+        required: true
+        type: string
+      target-ref:
+        description: "Branch/ref to check runs against."
+        required: false
+        type: string
+        default: main
+      max-days:
+        description: "Number of days without a successful run before alerting."
+        required: false
+        type: number
+        default: 7
+      trigger-release:
+        description: "When true, dispatches the workflow if it is stale. When false, only reports."
+        required: false
+        type: boolean
+        default: false
+      channel-id:
+        description: "Slack channel-id to post notification to."
+        required: false
+        type: string
+        default: ${{ vars.channel_id || 'NO_ID'}}
+
+jobs:
+  check-last-run:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    outputs:
+      stale: ${{ steps.check.outputs.stale }}
+      dispatched: ${{ steps.check.outputs.dispatched }}
+      status-text: ${{ steps.check.outputs.status-text }}
+    steps:
+      - name: Check last successful run of workflow
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ inputs.workflow }}
+          TARGET_REF: ${{ inputs.target-ref }}
+          MAX_DAYS: ${{ inputs.max-days }}
+          TRIGGER_RELEASE: ${{ inputs.trigger-release }}
+        run: |
+          set -euo pipefail
+
+          SHA=$(gh api "repos/${REPO}/commits/${TARGET_REF}" --jq '.sha')
+          AUTHOR=$(gh api "repos/${REPO}/commits/${SHA}" --jq '.author.login // ""')
+          echo "Latest commit on \`${TARGET_REF}\`: \`${SHA}\` (author: ${AUTHOR:-unknown})" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$AUTHOR" != "dependabot[bot]" ]; then
+            echo "Latest commit is not from dependabot; nothing to do." >> $GITHUB_STEP_SUMMARY
+            echo "stale=false" >> $GITHUB_OUTPUT
+            echo "dispatched=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Checking last successful run of \`${WORKFLOW}\` on \`${TARGET_REF}\`" >> $GITHUB_STEP_SUMMARY
+
+          LAST_RUN_AT=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?per_page=1&status=success&branch=${TARGET_REF}" --jq '.workflow_runs[0].created_at // ""')
+
+          if [ -z "$LAST_RUN_AT" ]; then
+            echo "**No successful run found**" >> $GITHUB_STEP_SUMMARY
+            echo "stale=true" >> $GITHUB_OUTPUT
+            echo "status-text=has never had a successful run on ${TARGET_REF}" >> $GITHUB_OUTPUT
+          else
+            LAST_RUN_EPOCH=$(date -d "$LAST_RUN_AT" +%s)
+            NOW_EPOCH=$(date +%s)
+            DAYS_SINCE=$(( (NOW_EPOCH - LAST_RUN_EPOCH) / 86400 ))
+
+            echo "**Last successful run:** ${LAST_RUN_AT} (${DAYS_SINCE} day(s) ago)" >> $GITHUB_STEP_SUMMARY
+            echo "**Max days threshold:** ${MAX_DAYS}" >> $GITHUB_STEP_SUMMARY
+
+            if [ "$DAYS_SINCE" -ge "$MAX_DAYS" ]; then
+              echo "**Status: ⚠️ Stale — threshold exceeded**" >> $GITHUB_STEP_SUMMARY
+              echo "stale=true" >> $GITHUB_OUTPUT
+              echo "status-text=last successful run on ${TARGET_REF} was ${DAYS_SINCE} day(s) ago (threshold: ${MAX_DAYS} days)" >> $GITHUB_OUTPUT
+            else
+              echo "**Status: ✅ OK**" >> $GITHUB_STEP_SUMMARY
+              echo "stale=false" >> $GITHUB_OUTPUT
+              echo "dispatched=false" >> $GITHUB_OUTPUT
+              echo "status-text=last successful run on ${TARGET_REF} was ${DAYS_SINCE} day(s) ago" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          if [ "$TRIGGER_RELEASE" = "true" ]; then
+            gh workflow run "${WORKFLOW}" --repo "${REPO}" --ref "${TARGET_REF}"
+            echo "Dispatched \`${WORKFLOW}\` on \`${TARGET_REF}\`." >> $GITHUB_STEP_SUMMARY
+            echo "dispatched=true" >> $GITHUB_OUTPUT
+          else
+            echo "dispatched=false" >> $GITHUB_OUTPUT
+          fi
+
+  post-to-slack-if-triggered:
+    needs: check-last-run
+    if: success() && needs.check-last-run.outputs.dispatched == 'true' && inputs.channel-id != 'NO_ID'
+    uses: entur/gha-slack/.github/workflows/post.yml@v2
+    with:
+      channel_id: ${{ inputs.channel-id }}
+      message: "🔵 ${{ github.repository }} - Triggered ${{ inputs.workflow }} on ${{ inputs.target-ref }} (${{ needs.check-last-run.outputs.status-text }})"
+    secrets: inherit
+
+  post-to-slack-if-stale:
+    needs: check-last-run
+    if: success() && needs.check-last-run.outputs.stale == 'true' && needs.check-last-run.outputs.dispatched == 'false' && inputs.channel-id != 'NO_ID'
+    uses: entur/gha-slack/.github/workflows/post.yml@v2
+    with:
+      channel_id: ${{ inputs.channel-id }}
+      message: "⚠️ ${{ github.repository }} - ${{ inputs.workflow }} ${{ needs.check-last-run.outputs.status-text }}"
+    secrets: inherit
+
+  post-fail-to-slack-if-fail:
+    needs: check-last-run
+    if: failure() && inputs.channel-id != 'NO_ID'
+    uses: entur/gha-slack/.github/workflows/post.yml@v2
+    with:
+      channel_id: ${{ inputs.channel-id }}
+      message: "⚫ ${{ github.repository }} - Check last workflow run failed for ${{ inputs.workflow }}"
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds a new reusable workflow `check-last-workflow-run.yml` that checks if a given workflow has had a successful run within a configurable number of days (default: 7)
- Only acts when the latest commit on the target ref is from `dependabot[bot]`
- Optionally triggers the workflow via `trigger-release: true` input; otherwise only sends a Slack warning

## Test plan
- [ ] Call the workflow from a repo with `trigger-release: false` and verify Slack warning is posted when stale
- [ ] Call the workflow with `trigger-release: true` and verify the target workflow is dispatched and Slack shows 🔵
- [ ] Verify no action is taken when latest commit is not from dependabot