### PR TITLE
Fix: add contents: read permission for commit API call

### DIFF
--- a/.github/workflows/check-last-workflow-run.yml
+++ b/.github/workflows/check-last-workflow-run.yml
@@ -34,6 +34,7 @@ jobs:
   check-last-run:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       actions: write
     outputs:
       stale: ${{ steps.check.outputs.stale }}


### PR DESCRIPTION
The job was failing with HTTP 403 because the reusable workflow only declared `actions: write` in its `permissions` block. Reusable workflows can only restrict the caller's token — since `contents: read` was missing from the block it got stripped, causing the `gh api repos/.../commits/main` call to fail.