### PR TITLE
Update + Pin non-entur GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -53,11 +53,11 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Dependabot metadata
         id: meta
         if: github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Decide whether to auto-merge
         id: decide
         if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -53,11 +53,11 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Dependabot metadata
         id: meta
         if: github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
       - name: Decide whether to auto-merge
         id: decide
         if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/build-jar-gradle.yml
+++ b/.github/workflows/build-jar-gradle.yml
@@ -20,14 +20,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Build with Gradle Wrapper
         run: ./gradlew clean build --no-daemon
         env:
@@ -37,14 +37,14 @@ jobs:
           ARTIFACTORY_AUTH_TOKEN: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
       - name: Archive Build Artifacts
         if: success()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app
           path: build/libs
           retention-days: 4
           overwrite: true
       - name: Upload test artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/build-jar-gradle.yml
+++ b/.github/workflows/build-jar-gradle.yml
@@ -20,14 +20,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       - name: Build with Gradle Wrapper
         run: ./gradlew clean build --no-daemon
         env:
@@ -37,14 +37,14 @@ jobs:
           ARTIFACTORY_AUTH_TOKEN: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
       - name: Archive Build Artifacts
         if: success()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: app
           path: build/libs
           retention-days: 4
           overwrite: true
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: test-results-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/build-jar-maven.yml
+++ b/.github/workflows/build-jar-maven.yml
@@ -20,9 +20,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
@@ -30,7 +30,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -49,14 +49,14 @@ jobs:
           echo "Artifact built and stored, ready for docker deploy step to fetch" >> $GITHUB_STEP_SUMMARY
       - name: Archive Build Artifacts
         if: success()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app
           path: libs
           retention-days: 4
           overwrite: true
       - name: Upload Surefire Reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/build-jar-maven.yml
+++ b/.github/workflows/build-jar-maven.yml
@@ -20,9 +20,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
@@ -30,7 +30,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -49,14 +49,14 @@ jobs:
           echo "Artifact built and stored, ready for docker deploy step to fetch" >> $GITHUB_STEP_SUMMARY
       - name: Archive Build Artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: app
           path: libs
           retention-days: 4
           overwrite: true
       - name: Upload Surefire Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/check-should-release.yml
+++ b/.github/workflows/check-should-release.yml
@@ -38,7 +38,7 @@ jobs:
       release_reason: ${{ steps.evaluate-release.outputs.release_reason }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/check-should-release.yml
+++ b/.github/workflows/check-should-release.yml
@@ -38,7 +38,7 @@ jobs:
       release_reason: ${{ steps.evaluate-release.outputs.release_reason }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/gradle-open-source-increment-version-and-release-to-maven-central.yml
+++ b/.github/workflows/gradle-open-source-increment-version-and-release-to-maven-central.yml
@@ -74,17 +74,17 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-tags: true
           fetch-depth: ${{ inputs.fetch-depth }}
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Publish
         id: publish
         env:
@@ -197,7 +197,7 @@ jobs:
           echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/gradle-open-source-increment-version-and-release-to-maven-central.yml
+++ b/.github/workflows/gradle-open-source-increment-version-and-release-to-maven-central.yml
@@ -74,17 +74,17 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-tags: true
           fetch-depth: ${{ inputs.fetch-depth }}
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       - name: Publish
         id: publish
         env:
@@ -197,7 +197,7 @@ jobs:
           echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/gradle-open-source-release-tag-to-maven-central.yml
+++ b/.github/workflows/gradle-open-source-release-tag-to-maven-central.yml
@@ -75,24 +75,24 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: inputs.ref == ''
         with:
           fetch-tags: true
           fetch-depth: ${{ inputs.fetch-depth }}
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: inputs.ref != ''
         with:
           ref: ${{ inputs.ref }}
           fetch-tags: true
           fetch-depth: ${{ inputs.fetch-depth }}
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Publish
         id: publish
         env:
@@ -146,7 +146,7 @@ jobs:
           echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/gradle-open-source-release-tag-to-maven-central.yml
+++ b/.github/workflows/gradle-open-source-release-tag-to-maven-central.yml
@@ -75,24 +75,24 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: inputs.ref == ''
         with:
           fetch-tags: true
           fetch-depth: ${{ inputs.fetch-depth }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: inputs.ref != ''
         with:
           ref: ${{ inputs.ref }}
           fetch-tags: true
           fetch-depth: ${{ inputs.fetch-depth }}
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       - name: Publish
         id: publish
         env:
@@ -146,7 +146,7 @@ jobs:
           echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/gradle-open-source-verify.yml
+++ b/.github/workflows/gradle-open-source-verify.yml
@@ -31,14 +31,14 @@ jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Build with Gradle Wrapper
         run: |
           GRADLE_LOG_ARGUMENT=""
@@ -53,7 +53,7 @@ jobs:
           ./gradlew ${{ inputs.tasks }} $GRADLE_LOG_ARGUMENT --stacktrace
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
             path: |

--- a/.github/workflows/gradle-open-source-verify.yml
+++ b/.github/workflows/gradle-open-source-verify.yml
@@ -31,14 +31,14 @@ jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       - name: Build with Gradle Wrapper
         run: |
           GRADLE_LOG_ARGUMENT=""
@@ -53,7 +53,7 @@ jobs:
           ./gradlew ${{ inputs.tasks }} $GRADLE_LOG_ARGUMENT --stacktrace
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
             name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
             path: |

--- a/.github/workflows/gradle-release-sona.yml
+++ b/.github/workflows/gradle-release-sona.yml
@@ -39,17 +39,17 @@ jobs:
   gradle-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Publish
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_AUTH_USER }}
@@ -140,7 +140,7 @@ jobs:
           git push --tags
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/gradle-release-sona.yml
+++ b/.github/workflows/gradle-release-sona.yml
@@ -39,17 +39,17 @@ jobs:
   gradle-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       - name: Publish
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_AUTH_USER }}
@@ -140,7 +140,7 @@ jobs:
           git push --tags
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/gradle-release-tag-sona.yml
+++ b/.github/workflows/gradle-release-tag-sona.yml
@@ -39,14 +39,14 @@ jobs:
   gradle-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       - name: Publish
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_AUTH_USER }}
@@ -83,7 +83,7 @@ jobs:
           ./gradlew ${{ inputs.tasks }} -Pversion=$CURRENT_VERSION -Psigning.gnupg.passphrase=$SONATYPE_GPG_KEY_PASSWORD -Psigning.gnupg.keyName=$SONATYPE_GPG_KEY_NAME -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD $GRADLE_LOG_ARGUMENT --stacktrace
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/gradle-release-tag-sona.yml
+++ b/.github/workflows/gradle-release-tag-sona.yml
@@ -39,14 +39,14 @@ jobs:
   gradle-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Publish
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_AUTH_USER }}
@@ -83,7 +83,7 @@ jobs:
           ./gradlew ${{ inputs.tasks }} -Pversion=$CURRENT_VERSION -Psigning.gnupg.passphrase=$SONATYPE_GPG_KEY_PASSWORD -Psigning.gnupg.keyName=$SONATYPE_GPG_KEY_NAME -PsonatypeUsername=$SONATYPE_USERNAME -PsonatypePassword=$SONATYPE_PASSWORD $GRADLE_LOG_ARGUMENT --stacktrace
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       message: ${{ steps.evaluate.outputs.message }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Dependabot branch count
         id: count
         env:

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       message: ${{ steps.evaluate.outputs.message }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Dependabot branch count
         id: count
         env:

--- a/.github/workflows/lint-proto.yml
+++ b/.github/workflows/lint-proto.yml
@@ -13,7 +13,7 @@ jobs:
     name: Proto lint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Download buf binary
         run: |
           # Download bufbuild/buf from github

--- a/.github/workflows/lint-proto.yml
+++ b/.github/workflows/lint-proto.yml
@@ -13,7 +13,7 @@ jobs:
     name: Proto lint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download buf binary
         run: |
           # Download bufbuild/buf from github

--- a/.github/workflows/maven-open-source-increment-version-and-release-to-maven-central.yml
+++ b/.github/workflows/maven-open-source-increment-version-and-release-to-maven-central.yml
@@ -74,12 +74,12 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-tags: true
           fetch-depth: ${{ inputs.fetch-depth }}
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -87,7 +87,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-open-source-increment-version-and-release-to-maven-central.yml
+++ b/.github/workflows/maven-open-source-increment-version-and-release-to-maven-central.yml
@@ -74,12 +74,12 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-tags: true
           fetch-depth: ${{ inputs.fetch-depth }}
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -87,7 +87,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-open-source-release-tag-to-maven-central.yml
+++ b/.github/workflows/maven-open-source-release-tag-to-maven-central.yml
@@ -74,19 +74,19 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: inputs.ref == ''
         with:
           fetch-tags: true
           fetch-depth: inputs.fetch-depth
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: inputs.ref != ''
         with:
           ref: ${{ inputs.inputs.ref }}
           fetch-tags: true
           fetch-depth: inputs.fetch-depth
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -94,7 +94,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-open-source-release-tag-to-maven-central.yml
+++ b/.github/workflows/maven-open-source-release-tag-to-maven-central.yml
@@ -74,19 +74,19 @@ jobs:
       tag: ${{ steps.publish.outputs.tag }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: inputs.ref == ''
         with:
           fetch-tags: true
           fetch-depth: inputs.fetch-depth
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: inputs.ref != ''
         with:
           ref: ${{ inputs.inputs.ref }}
           fetch-tags: true
           fetch-depth: inputs.fetch-depth
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -94,7 +94,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-open-source-release-tag-to-maven-central.yml
+++ b/.github/workflows/maven-open-source-release-tag-to-maven-central.yml
@@ -78,7 +78,7 @@ jobs:
         if: inputs.ref == ''
         with:
           fetch-tags: true
-          fetch-depth: inputs.fetch-depth
+          fetch-depth: ${{ inputs.fetch-depth }}
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: inputs.ref != ''
         with:

--- a/.github/workflows/maven-open-source-release-tag-to-maven-central.yml
+++ b/.github/workflows/maven-open-source-release-tag-to-maven-central.yml
@@ -82,9 +82,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: inputs.ref != ''
         with:
-          ref: ${{ inputs.inputs.ref }}
+          ref: ${{ inputs.ref }}
           fetch-tags: true
-          fetch-depth: inputs.fetch-depth
+          fetch-depth: ${{ inputs.fetch-depth }}
       - name: Set up Java ${{ inputs.java-version }}
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -27,14 +27,14 @@ jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -71,7 +71,7 @@ jobs:
             fi
           fi
       - name: Upload Surefire Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/maven-open-source-verify.yml
+++ b/.github/workflows/maven-open-source-verify.yml
@@ -27,14 +27,14 @@ jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -71,7 +71,7 @@ jobs:
             fi
           fi
       - name: Upload Surefire Reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/maven-release-sona.yml
+++ b/.github/workflows/maven-release-sona.yml
@@ -26,12 +26,12 @@ jobs:
   maven-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
@@ -39,7 +39,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-release-sona.yml
+++ b/.github/workflows/maven-release-sona.yml
@@ -26,12 +26,12 @@ jobs:
   maven-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
@@ -39,7 +39,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -26,12 +26,12 @@ jobs:
   maven-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
@@ -39,7 +39,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -67,7 +67,7 @@ jobs:
           git push --tags
           echo "Release commit has been tagged"
       - name: Upload Surefire Reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -26,12 +26,12 @@ jobs:
   maven-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
@@ -39,7 +39,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -67,7 +67,7 @@ jobs:
           git push --tags
           echo "Release commit has been tagged"
       - name: Upload Surefire Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/validate-jar-gradle-sona.yml
+++ b/.github/workflows/validate-jar-gradle-sona.yml
@@ -22,14 +22,14 @@ jobs:
   validate-gradle-build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Build with Gradle Wrapper
         run: |
           GRADLE_LOG_ARGUMENT=""
@@ -44,7 +44,7 @@ jobs:
           ./gradlew ${{ inputs.tasks }} $GRADLE_LOG_ARGUMENT --stacktrace
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
             path: |

--- a/.github/workflows/validate-jar-gradle-sona.yml
+++ b/.github/workflows/validate-jar-gradle-sona.yml
@@ -22,14 +22,14 @@ jobs:
   validate-gradle-build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       - name: Build with Gradle Wrapper
         run: |
           GRADLE_LOG_ARGUMENT=""
@@ -44,7 +44,7 @@ jobs:
           ./gradlew ${{ inputs.tasks }} $GRADLE_LOG_ARGUMENT --stacktrace
       - name: Store build reports
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
             name: reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
             path: |

--- a/.github/workflows/validate-jar-gradle.yml
+++ b/.github/workflows/validate-jar-gradle.yml
@@ -24,14 +24,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       - name: Build with Gradle Wrapper
         run: ./gradlew clean build --no-daemon
         env:
@@ -40,7 +40,7 @@ jobs:
           ARTIFACTORY_AUTH_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
           ARTIFACTORY_AUTH_TOKEN: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: test-results-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/validate-jar-gradle.yml
+++ b/.github/workflows/validate-jar-gradle.yml
@@ -24,14 +24,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Build with Gradle Wrapper
         run: ./gradlew clean build --no-daemon
         env:
@@ -40,7 +40,7 @@ jobs:
           ARTIFACTORY_AUTH_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
           ARTIFACTORY_AUTH_TOKEN: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
       - name: Upload test artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/validate-jar-maven-sona.yml
+++ b/.github/workflows/validate-jar-maven-sona.yml
@@ -11,14 +11,14 @@ jobs:
   validate-maven-build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/validate-jar-maven-sona.yml
+++ b/.github/workflows/validate-jar-maven-sona.yml
@@ -11,14 +11,14 @@ jobs:
   validate-maven-build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/validate-jar-maven.yml
+++ b/.github/workflows/validate-jar-maven.yml
@@ -43,9 +43,9 @@ jobs:
     outputs:
       deploy-message: ${{ steps.autodeploy.outputs.message }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
@@ -53,7 +53,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -103,7 +103,7 @@ jobs:
             fi
           fi
       - name: Upload Surefire Reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -115,7 +115,7 @@ jobs:
           mv target/app.jar libs
       - name: Archive Build Artifacts
         if: success() && inputs.upload-artifact == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app
           path: libs

--- a/.github/workflows/validate-jar-maven.yml
+++ b/.github/workflows/validate-jar-maven.yml
@@ -43,9 +43,9 @@ jobs:
     outputs:
       deploy-message: ${{ steps.autodeploy.outputs.message }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Java ${{ inputs.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c77aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ inputs.java-version }}
           distribution: liberica
@@ -53,7 +53,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -103,7 +103,7 @@ jobs:
             fi
           fi
       - name: Upload Surefire Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: surefire-reports-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -115,7 +115,7 @@ jobs:
           mv target/app.jar libs
       - name: Archive Build Artifacts
         if: success() && inputs.upload-artifact == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: app
           path: libs


### PR DESCRIPTION
## Summary

Pins all third-party (non-entur) GitHub Actions to specific commit SHAs for supply chain security. Version tags are preserved as inline comments.

## Why

Pinning to SHAs ensures that the exact code reviewed is what runs, protecting against tag mutation or supply chain attacks.