### PR TITLE
Opt-in approval gate and changelog Slack notification for cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,3 +1,28 @@
+# CD pipeline for one environment: terraform plan -> apply -> helm deploy.
+#
+# Concurrency model (scoped per environment + repository):
+#   - tf-plan:  cancel-in-progress=true  -> read-only (runs with -lock=false),
+#               so a newer push may freely cancel an in-flight plan.
+#   - tf-apply: cancel-in-progress=false in its OWN group.
+#   - deploy:   cancel-in-progress=false in its OWN group (distinct from apply).
+#
+# Why apply and deploy use SEPARATE groups: a job waiting at an environment
+# approval gate counts as "pending", and GitHub keeps only one pending member
+# per group ("previously pending job ... canceled"). If apply and deploy shared
+# one group, the deploy job's claim on that group would cancel tf-apply the
+# instant it paused for approval. Separate groups remove that self-cancel.
+#
+# Accepted trade-off ("latest approved commit wins"): apply and deploy are NOT
+# strictly atomic across runs. apply.yml (gha-terraform) and deploy.yml
+# (gha-helm) each carry their own environment approval gate, so there is always
+# a cancellable "waiting for approval" window between a finished apply and the
+# deploy. If an older run sits at the deploy gate while a newer run is approved
+# all the way through its own apply, the newer run's deploy supersedes (cancels)
+# the older one's -- the older run may then have applied infra without deploying,
+# which the newer run's deploy corrects. Strict atomicity would require a single
+# approval gate (i.e. an ungated deploy); see the unused terraform-plan.yml /
+# terraform-apply.yml helpers for that alternative.
+
 name: CD
 
 on:
@@ -78,6 +103,11 @@ jobs:
 
   tf-plan:
     name: Terraform Plan
+    # Plan is read-only (runs with -lock=false), so a newer push may freely
+    # cancel an in-progress plan from an older commit.
+    concurrency:
+      group: cd-tf-plan-${{ inputs.environment }}-${{ github.repository }}
+      cancel-in-progress: true
     uses: entur/gha-terraform/.github/workflows/plan.yml@v2
     with:
       environment: ${{ inputs.environment }}
@@ -86,8 +116,9 @@ jobs:
   tf-apply:
     name: Terraform Apply
     needs: [tf-plan]
+    # Own group, distinct from deploy below (see concurrency note at top of file).
     concurrency:
-      group: cd-deploy-${{ inputs.environment }}-${{ github.repository }}
+      group: cd-tf-apply-${{ inputs.environment }}-${{ github.repository }}
       cancel-in-progress: false
     uses: entur/gha-terraform/.github/workflows/apply.yml@v2
     with:
@@ -100,8 +131,10 @@ jobs:
     needs: [tf-apply]
     # Terraform apply is skipped on empty plan. This if ensures that job is run even if previous step is skipped
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    # Own group, distinct from tf-apply (see concurrency note at top of file).
+    # Serializes deploys for the same environment across runs.
     concurrency:
-      group: cd-deploy-${{ inputs.environment }}-${{ github.repository }}
+      group: cd-helm-deploy-${{ inputs.environment }}-${{ github.repository }}
       cancel-in-progress: false
     uses: entur/gha-helm/.github/workflows/deploy.yml@v1
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,25 +1,6 @@
-# CD pipeline for one environment: terraform plan -> [approval] -> apply -> deploy.
-#
-# Approval gate (opt-in via require-approval, default false): a standalone
-# `approve` job pauses after the plan on a single "approval" GitHub Environment
-# whose required reviewers gate the run. One gate covers both apply and deploy
-# -- move required reviewers OFF tst/prd and ONTO "approval" so they don't gate
-# twice. Which environment is being approved is conveyed by the notify-diff
-# Slack message and the "Approve deploy to <env>" job name, not by the
-# environment name. When false the job is skipped and the pipeline flows
-# straight through.
-#
-# Concurrency (per environment + repository):
-#   - tf-plan:  cancel-in-progress=true -- read-only, so a newer push may cancel
-#               an in-flight plan.
-#   - approve:  no group -- it only waits, so runs may queue here without
-#               cancelling or blocking each other or newer runs. Nothing is
-#               auto-superseded: approve the NEWEST and cancel older ones by hand
-#               (approving an older run deploys an older image).
-#   - tf-apply / deploy: cancel-in-progress=false in separate groups -- these
-#               serialize across runs and a started apply/deploy is never
-#               interrupted. Not atomic across runs; the newest approved deploy
-#               wins.
+# CD for one environment: terraform plan -> [approval] -> apply -> deploy.
+# Approval is opt-in (require-approval) and gates on an "approval" Environment;
+# its reviewers must NOT also be on tst/prd, or apply and deploy gate twice.
 
 name: CD
 
@@ -49,12 +30,7 @@ on:
         type: boolean
         default: true
       require-approval:
-        description: >
-          Require manual approval before apply/deploy. When true, a standalone
-          job pauses the pipeline on a GitHub Environment named "approval" (must
-          exist with required reviewers) right after the plan. A single gate then
-          covers both terraform apply and helm deploy; the target environment is
-          shown by the Slack notification and the job name.
+        description: Require manual approval on the "approval" Environment before apply/deploy
         required: false
         type: boolean
         default: false
@@ -102,7 +78,6 @@ jobs:
           echo "compare_url=$URL" >> "$GITHUB_OUTPUT"
           echo "$URL"
 
-          # Per-environment emoji (falls back to :clipboard: for unknown envs).
           case "$ENVIRONMENT" in
             prd) EMOJI=":prod:" ;;
             tst) EMOJI=":staging:" ;;
@@ -111,7 +86,6 @@ jobs:
           esac
 
           MESSAGE="$EMOJI New <$URL|changelog> for $REPO_NAME ${GITHUB_SHA::7}."
-          # Add the approve link only when this run actually gates for approval.
           if [ "$REQUIRE_APPROVAL" = "true" ]; then
             MESSAGE="$MESSAGE <$RUN_URL|Approve deployment>"
           fi
@@ -119,8 +93,6 @@ jobs:
 
   tf-plan:
     name: Terraform Plan
-    # Plan is read-only (runs with -lock=false), so a newer push may freely
-    # cancel an in-progress plan from an older commit.
     concurrency:
       group: cd-tf-plan-${{ inputs.environment }}-${{ github.repository }}
       cancel-in-progress: true
@@ -129,10 +101,7 @@ jobs:
       environment: ${{ inputs.environment }}
     secrets: inherit
 
-  # Posted right before the approval gate (needs tf-plan) so the changelog and
-  # the "Approve deployment" link land in Slack exactly when a reviewer is
-  # needed. The message -- env emoji, and the approve link when require-approval
-  # is set -- is built in the git-diff-url job.
+  # needs tf-plan so the changelog + approve link post right before the gate.
   notify-diff:
     name: Notify Git Diff
     needs: [git-diff-url, tf-plan]
@@ -144,23 +113,11 @@ jobs:
     secrets: inherit
 
   approve:
-    name: Approve deploy to ${{ inputs.environment }}
-    # Waits for notify-diff so the "Approve deployment" Slack message is posted
-    # right before the gate opens. Still runs when notify-diff is skipped (no
-    # changelog / notify-changelog off) or fails, hence the status-function
-    # guard rather than a plain input check.
+    name: Approve deployment
     needs: [tf-plan, notify-diff]
-    # Opt-in gate. When require-approval is false this job is skipped and every
-    # downstream `if` below treats 'skipped' as "proceed".
+    # !cancelled() so this still runs when notify-diff is skipped.
     if: ${{ !cancelled() && inputs.require-approval && needs.tf-plan.result == 'success' }}
     runs-on: ubuntu-latest
-    # Pauses on a single "approval" GitHub Environment where the required
-    # reviewers live; the target env is conveyed by the Slack message and this
-    # job's name, not the environment name. No concurrency group: the job only
-    # waits and holds nothing, so several runs may sit at the gate at once
-    # without cancelling or blocking each other or a newer run's apply/deploy.
-    # Nothing is auto-cancelled -- approve the newest waiting run and
-    # decline/cancel older ones (see concurrency note at top).
     environment: approval
     steps:
       - name: Approved
@@ -169,14 +126,10 @@ jobs:
   tf-apply:
     name: Terraform Apply
     needs: [tf-plan, approve]
-    # Run once the plan succeeded and approval passed (or was not required, i.e.
-    # the approve job was skipped). A declined or superseded approval leaves
-    # approve in 'failure'/'cancelled', which stops the pipeline here.
     if: >
       always() && !cancelled()
       && needs.tf-plan.result == 'success'
       && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
-    # Own group, distinct from deploy below (see concurrency note at top of file).
     concurrency:
       group: cd-tf-apply-${{ inputs.environment }}-${{ github.repository }}
       cancel-in-progress: false
@@ -189,15 +142,11 @@ jobs:
   deploy:
     name: Deploy
     needs: [tf-apply, approve]
-    # Terraform apply is skipped on an empty plan, so tolerate a skipped apply.
-    # Proceed only if approval passed (or was not required) and nothing failed.
     if: >
       always() && !cancelled()
       && !contains(needs.*.result, 'failure')
       && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
       && (needs.tf-apply.result == 'success' || needs.tf-apply.result == 'skipped')
-    # Own group, distinct from tf-apply (see concurrency note at top of file).
-    # Serializes deploys for the same environment across runs.
     concurrency:
       group: cd-helm-deploy-${{ inputs.environment }}-${{ github.repository }}
       cancel-in-progress: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,22 +6,51 @@
 #   - tf-apply: cancel-in-progress=false in its OWN group.
 #   - deploy:   cancel-in-progress=false in its OWN group (distinct from apply).
 #
-# Why apply and deploy use SEPARATE groups: a job waiting at an environment
-# approval gate counts as "pending", and GitHub keeps only one pending member
-# per group ("previously pending job ... canceled"). If apply and deploy shared
-# one group, the deploy job's claim on that group would cancel tf-apply the
-# instant it paused for approval. Separate groups remove that self-cancel.
+# Why plan, apply and deploy use SEPARATE groups: a job waiting at an
+# environment approval gate HOLDS its concurrency group until it is approved
+# or cancelled (see the superseding note below). A group is held per JOB, so
+# with a shared group it would be released between apply and deploy, letting
+# jobs of DIFFERENT runs compete for it (an older run's deploy vs a newer
+# run's apply). A run parked at any gate would then block every job of a
+# newer run -- including the read-only plan -- and GitHub's
+# one-pending-per-group dedup ("previously pending job ... canceled") would
+# cancel other runs' jobs mid-pipeline. With separate groups a newer run
+# always progresses to its own approval gates, and each group only ever
+# serializes the same job type across runs.
 #
 # Accepted trade-off ("latest approved commit wins"): apply and deploy are NOT
 # strictly atomic across runs. apply.yml (gha-terraform) and deploy.yml
 # (gha-helm) each carry their own environment approval gate, so there is always
 # a cancellable "waiting for approval" window between a finished apply and the
-# deploy. If an older run sits at the deploy gate while a newer run is approved
-# all the way through its own apply, the newer run's deploy supersedes (cancels)
-# the older one's -- the older run may then have applied infra without deploying,
-# which the newer run's deploy corrects. Strict atomicity would require a single
-# approval gate (i.e. an ungated deploy); see the unused terraform-plan.yml /
-# terraform-apply.yml helpers for that alternative.
+# deploy. An older run parked at the deploy gate is superseded -- cancelled by
+# a newer run's cancel-superseded sweep, or by hand -- and may thus have
+# applied infra without deploying it; the newer run's deploy corrects that.
+# Strict atomicity would require a single approval gate (i.e. an ungated
+# deploy); see the unused terraform-plan.yml / terraform-apply.yml helpers for
+# that alternative.
+#
+# Superseding ("newest run wins", the cancel-superseded job): concurrency alone
+# cannot clear a run parked at an approval gate. A gate-waiting job HOLDS its
+# concurrency group (run status "waiting"), and with cancel-in-progress=false
+# GitHub only dedupes the pending queue behind it -- so newer runs stack up as
+# "pending" until someone manually approves or cancels the old run.
+# cancel-in-progress=true is no fix either: it cannot tell "waiting at the
+# gate" (safe to cancel) from "terraform apply is executing" (must not be
+# interrupted). So the cancel-superseded job, run at the start of every cd.yml
+# call, explicitly cancels OLDER runs of the same caller workflow + branch
+# whose run status is "waiting" or "pending" -- states in which no job is
+# executing, i.e. exactly the runs a human would cancel by hand. A run that is
+# actively applying/deploying is never touched; the concurrency groups still
+# serialize those.
+#
+# Accepted gap: the sweep is a point-in-time check, so it misses a run that
+# enters "waiting" AFTER the sweep ran (e.g. an older run whose apply was
+# executing during the sweep and then parked at its deploy gate). Such a run
+# holds its group until the next push sweeps it away, or until someone
+# approves/cancels it manually -- rare, since it requires the older run to be
+# actively approved while the newer one is mid-stage. NOTE: the sweep requires
+# the CALLER to grant `actions: write` on the jobs that call cd.yml, otherwise
+# it logs a warning and does nothing.
 
 name: CD
 
@@ -100,6 +129,33 @@ jobs:
       channel_id: ${{ inputs.channel-id }}
       message: "📋 New <${{ needs.git-diff-url.outputs.compare_url }}|changelog> for ${{ github.event.repository.name }} ${{ needs.git-diff-url.outputs.short_sha }} in ${{ inputs.environment }}"
     secrets: inherit
+
+  cancel-superseded:
+    name: Cancel Superseded Runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel older runs stuck at approval gates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Cancels older runs of the same caller workflow + branch whose run
+        # status is "waiting" (parked at an environment approval gate) or
+        # "pending" (queued behind a concurrency group). In both states no
+        # job is executing, so cancelling is safe. Never fails the pipeline:
+        # without `actions: write` from the caller it only logs a warning.
+        run: |
+          WORKFLOW_ID=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .workflow_id) || {
+            echo "::warning::Could not resolve workflow id; skipping supersede sweep"
+            exit 0
+          }
+          for STATUS in waiting pending; do
+            gh api "repos/${{ github.repository }}/actions/workflows/${WORKFLOW_ID}/runs?branch=${{ github.ref_name }}&status=${STATUS}&per_page=100" \
+              --jq ".workflow_runs[] | select(.run_number < ${{ github.run_number }}) | .id" || true
+          done | sort -u | while read -r RUN_ID; do
+            [ -z "$RUN_ID" ] && continue
+            echo "Cancelling superseded run ${RUN_ID} (superseded by run #${{ github.run_number }})"
+            gh api -X POST "repos/${{ github.repository }}/actions/runs/${RUN_ID}/cancel" \
+              || echo "::warning::Could not cancel run ${RUN_ID} -- does the caller grant 'actions: write'?"
+          done
 
   tf-plan:
     name: Terraform Plan

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,13 @@
 # CD pipeline for one environment: terraform plan -> [approval] -> apply -> deploy.
 #
 # Approval gate (opt-in via require-approval, default false): a standalone
-# `approve` job pauses after the plan on a per-environment "approval-<env>"
-# GitHub Environment (e.g. approval-prd) whose required reviewers gate the run,
-# so the target is clear in the approval dialog and notifications. One gate
-# covers both apply and deploy -- move required reviewers OFF tst/prd and ONTO
-# the matching approval-<env> so they don't gate twice. When false the job is
-# skipped and the pipeline flows straight through.
+# `approve` job pauses after the plan on a single "approval" GitHub Environment
+# whose required reviewers gate the run. One gate covers both apply and deploy
+# -- move required reviewers OFF tst/prd and ONTO "approval" so they don't gate
+# twice. Which environment is being approved is conveyed by the notify-diff
+# Slack message and the "Approve deploy to <env>" job name, not by the
+# environment name. When false the job is skipped and the pipeline flows
+# straight through.
 #
 # Concurrency (per environment + repository):
 #   - tf-plan:  cancel-in-progress=true -- read-only, so a newer push may cancel
@@ -50,10 +51,10 @@ on:
       require-approval:
         description: >
           Require manual approval before apply/deploy. When true, a standalone
-          job pauses the pipeline on a per-environment GitHub Environment named
-          "approval-<environment>" (e.g. approval-prd; must exist with required
-          reviewers) right after the plan, so the approval dialog names the exact
-          target. A single gate then covers both terraform apply and helm deploy.
+          job pauses the pipeline on a GitHub Environment named "approval" (must
+          exist with required reviewers) right after the plan. A single gate then
+          covers both terraform apply and helm deploy; the target environment is
+          shown by the Slack notification and the job name.
         required: false
         type: boolean
         default: false
@@ -66,17 +67,21 @@ jobs:
       deployments: read
     outputs:
       compare_url: ${{ steps.compare.outputs.compare_url }}
-      short_sha: ${{ steps.compare.outputs.short_sha }}
+      slack_message: ${{ steps.compare.outputs.slack_message }}
     steps:
-      - name: Get compare URL since last successful deployment
+      - name: Build changelog Slack message
         id: compare
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REQUIRE_APPROVAL: ${{ inputs.require-approval }}
         run: |
           DEPLOYED_SHA=$(
             gh api "repos/${{ github.repository }}/deployments" \
               -X GET \
-              -f environment="${{ inputs.environment }}" \
+              -f environment="$ENVIRONMENT" \
               -f per_page=20 \
               --jq '.[] | "\(.sha) \(.statuses_url)"' | \
             while IFS=' ' read -r sha statuses_url; do
@@ -88,25 +93,29 @@ jobs:
             done
           )
 
-          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-
-          if [ -n "$DEPLOYED_SHA" ]; then
-            URL="https://github.com/${{ github.repository }}/compare/${DEPLOYED_SHA}...${{ github.sha }}"
-            echo "compare_url=$URL" >> $GITHUB_OUTPUT
-            echo "$URL"
-          else
-            echo "No previous successful deployment found for ${{ inputs.environment }}"
+          if [ -z "$DEPLOYED_SHA" ]; then
+            echo "No previous successful deployment found for $ENVIRONMENT"
+            exit 0
           fi
 
-  notify-diff:
-    name: Notify Git Diff
-    needs: git-diff-url
-    if: inputs.notify-changelog && needs.git-diff-url.outputs.compare_url != ''
-    uses: entur/gha-slack/.github/workflows/post.yml@v2
-    with:
-      channel_id: ${{ inputs.channel-id }}
-      message: "📋 New <${{ needs.git-diff-url.outputs.compare_url }}|changelog> for ${{ github.event.repository.name }} ${{ needs.git-diff-url.outputs.short_sha }} in ${{ inputs.environment }}"
-    secrets: inherit
+          URL="${{ github.server_url }}/${{ github.repository }}/compare/${DEPLOYED_SHA}...${GITHUB_SHA}"
+          echo "compare_url=$URL" >> "$GITHUB_OUTPUT"
+          echo "$URL"
+
+          # Per-environment emoji (falls back to :clipboard: for unknown envs).
+          case "$ENVIRONMENT" in
+            prd) EMOJI=":prod:" ;;
+            tst) EMOJI=":staging:" ;;
+            dev) EMOJI=":dev:" ;;
+            *)   EMOJI=":clipboard:" ;;
+          esac
+
+          MESSAGE="$EMOJI New <$URL|changelog> for $REPO_NAME ${GITHUB_SHA::7}."
+          # Add the approve link only when this run actually gates for approval.
+          if [ "$REQUIRE_APPROVAL" = "true" ]; then
+            MESSAGE="$MESSAGE <$RUN_URL|Approve deployment>"
+          fi
+          echo "slack_message=$MESSAGE" >> "$GITHUB_OUTPUT"
 
   tf-plan:
     name: Terraform Plan
@@ -120,21 +129,39 @@ jobs:
       environment: ${{ inputs.environment }}
     secrets: inherit
 
+  # Posted right before the approval gate (needs tf-plan) so the changelog and
+  # the "Approve deployment" link land in Slack exactly when a reviewer is
+  # needed. The message -- env emoji, and the approve link when require-approval
+  # is set -- is built in the git-diff-url job.
+  notify-diff:
+    name: Notify Git Diff
+    needs: [git-diff-url, tf-plan]
+    if: ${{ inputs.notify-changelog && needs.git-diff-url.outputs.compare_url != '' }}
+    uses: entur/gha-slack/.github/workflows/post.yml@v2
+    with:
+      channel_id: ${{ inputs.channel-id }}
+      message: ${{ needs.git-diff-url.outputs.slack_message }}
+    secrets: inherit
+
   approve:
     name: Approve deploy to ${{ inputs.environment }}
-    needs: [tf-plan]
+    # Waits for notify-diff so the "Approve deployment" Slack message is posted
+    # right before the gate opens. Still runs when notify-diff is skipped (no
+    # changelog / notify-changelog off) or fails, hence the status-function
+    # guard rather than a plain input check.
+    needs: [tf-plan, notify-diff]
     # Opt-in gate. When require-approval is false this job is skipped and every
     # downstream `if` below treats 'skipped' as "proceed".
-    if: ${{ inputs.require-approval }}
+    if: ${{ !cancelled() && inputs.require-approval && needs.tf-plan.result == 'success' }}
     runs-on: ubuntu-latest
-    # Pauses on a per-environment "approval-<env>" GitHub Environment (e.g.
-    # approval-prd), so the target is unambiguous in the approval dialog and in
-    # review notifications. Required reviewers live on that environment. No
-    # concurrency group: the job only waits and holds nothing, so several runs
-    # may sit at the gate at once without cancelling or blocking each other or a
-    # newer run's apply/deploy. Nothing is auto-cancelled -- approve the newest
-    # waiting run and decline/cancel older ones (see concurrency note at top).
-    environment: approval-${{ inputs.environment }}
+    # Pauses on a single "approval" GitHub Environment where the required
+    # reviewers live; the target env is conveyed by the Slack message and this
+    # job's name, not the environment name. No concurrency group: the job only
+    # waits and holds nothing, so several runs may sit at the gate at once
+    # without cancelling or blocking each other or a newer run's apply/deploy.
+    # Nothing is auto-cancelled -- approve the newest waiting run and
+    # decline/cancel older ones (see concurrency note at top).
+    environment: approval
     steps:
       - name: Approved
         run: echo "Deployment of ${{ inputs.image }} to ${{ inputs.environment }} approved"
@@ -178,6 +205,5 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
       image: ${{ inputs.image }}
-      slack_channel_id: ${{ inputs.channel-id }}
       container_name: ${{ inputs.container-name }}
     secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,63 +1,47 @@
-# CD pipeline for one environment: terraform plan -> apply -> helm deploy.
+# CD pipeline for one environment: terraform plan -> [approval] -> apply -> deploy.
 #
-# Concurrency model (scoped per environment + repository):
-#   - tf-plan:  cancel-in-progress=true  -> read-only (runs with -lock=false),
-#               so a newer push may freely cancel an in-flight plan.
-#   - tf-apply: cancel-in-progress=false in its OWN group.
-#   - deploy:   cancel-in-progress=false in its OWN group (distinct from apply).
+# Approval gate (opt-in via the require-approval input):
+#   When require-approval is true, a standalone `approve` job pauses the
+#   pipeline on a GitHub Environment named "approval" (which the caller repo
+#   must create, with required reviewers) immediately after the plan -- so a
+#   reviewer can read the plan before anything is applied or deployed. Putting
+#   the gate in its OWN job, instead of relying on required reviewers on the
+#   tst/prd environments, buys two things:
+#     - one gate covers BOTH terraform apply and the helm deploy, so there is
+#       no more double approval, and
+#     - the wait happens in a job that does nothing else, which is what makes
+#       superseding safe (see the approve concurrency note below).
+#   Callers that opt in should move required reviewers OFF the tst/prd
+#   environments and ONTO "approval"; otherwise apply/deploy gate a second time.
+#   When require-approval is false (the default) the job is skipped and the
+#   pipeline flows straight through -- unchanged for existing callers.
 #
-# Why plan, apply and deploy use SEPARATE groups: a job waiting at an
-# environment approval gate HOLDS its concurrency group until it is approved
-# or cancelled (see the superseding note below). A group is held per JOB, so
-# with a shared group it would be released between apply and deploy, letting
-# jobs of DIFFERENT runs compete for it (an older run's deploy vs a newer
-# run's apply). A run parked at any gate would then block every job of a
-# newer run -- including the read-only plan -- and GitHub's
-# one-pending-per-group dedup ("previously pending job ... canceled") would
-# cancel other runs' jobs mid-pipeline. With separate groups a newer run
-# always progresses to its own approval gates, and each group only ever
-# serializes the same job type across runs.
+# Concurrency model (every group scoped per environment + repository):
+#   - tf-plan:  cancel-in-progress=true. The plan is read-only (runs with
+#               -lock=false), so a newer push may freely cancel an in-flight
+#               plan from an older commit.
+#   - approve:  cancel-in-progress=true. This is what supersedes stale runs: a
+#               job parked at the approval gate can be cancelled safely because
+#               it only waits -- it mutates nothing. So when a newer run reaches
+#               the gate, GitHub-native concurrency cancels the older run still
+#               parked there, and that run's apply/deploy never fire. A newer
+#               run is therefore never blocked by an older one waiting for
+#               approval -- the whole problem this pipeline sets out to solve.
+#               (This replaces an earlier pending_deployments "cancel-superseded"
+#               sweep and its need for the caller to grant `actions: write`.)
+#               cancel-in-progress could NOT be used while the gate lived inside
+#               apply/deploy, because there it cannot tell "waiting at the gate"
+#               (safe to cancel) from "terraform apply is executing" (must not
+#               be interrupted). Isolating the gate removes that ambiguity.
+#   - tf-apply: cancel-in-progress=false, in its own group. Serializes applies
+#               across runs; an apply that has started is never interrupted.
+#   - deploy:   cancel-in-progress=false, in its own group (distinct from
+#               apply). Serializes deploys across runs.
 #
-# Accepted trade-off ("latest approved commit wins"): apply and deploy are NOT
-# strictly atomic across runs. apply.yml (gha-terraform) and deploy.yml
-# (gha-helm) each carry their own environment approval gate, so there is always
-# a cancellable "waiting for approval" window between a finished apply and the
-# deploy. An older run parked at the deploy gate is superseded -- cancelled by
-# a newer run's cancel-superseded sweep, or by hand -- and may thus have
-# applied infra without deploying it; the newer run's deploy corrects that.
-# Strict atomicity would require a single approval gate (i.e. an ungated
-# deploy); see the unused terraform-plan.yml / terraform-apply.yml helpers for
-# that alternative.
-#
-# Superseding ("newest run wins", the cancel-superseded job): concurrency alone
-# cannot clear a run parked at an approval gate. A gate-waiting job HOLDS its
-# concurrency group (run status "waiting"), and with cancel-in-progress=false
-# GitHub only dedupes the pending queue behind it -- so newer runs stack up as
-# "pending" until someone manually approves or cancels the old run.
-# cancel-in-progress=true is no fix either: it cannot tell "waiting at the
-# gate" (safe to cancel) from "terraform apply is executing" (must not be
-# interrupted). So the cancel-superseded job, run at the start of every cd.yml
-# call, cancels OLDER runs of the same caller workflow + branch that are
-# waiting for approval into THE SAME ENVIRONMENT as this call (resolved via
-# the pending_deployments API) -- exactly the run a human would cancel by hand
-# before approving the newest one. Runs waiting at OTHER environments' gates
-# are left alone; they are swept only when a newer run reaches that
-# environment (e.g. a run waiting at the prd gate survives until a newer run
-# has been approved all the way to its own prd stage). Runs that are merely
-# "pending" (queued behind a concurrency group) are also left alone: GitHub's
-# one-pending-per-group dedup already keeps only the newest queued run per
-# group, and the groups are per environment. A run that is actively
-# applying/deploying is never touched; the concurrency groups still serialize
-# those.
-#
-# Accepted gap: the sweep is a point-in-time check, so it misses a run that
-# enters "waiting" AFTER the sweep ran (e.g. an older run whose apply was
-# executing during the sweep and then parked at its deploy gate). Such a run
-# holds its group until the next run entering that environment sweeps it, or
-# until someone approves/cancels it manually -- rare, since it requires the
-# older run to be actively approved while the newer one is mid-stage. NOTE:
-# the sweep requires the CALLER to grant `actions: write` on the jobs that
-# call cd.yml, otherwise it logs a warning and does nothing.
+# Accepted trade-off ("latest approved commit wins"): apply and deploy are not
+# strictly atomic across runs. Once approved, a run may finish its apply and
+# then lose the deploy group to another approved run; the newest approved
+# deploy wins, which is the intended outcome.
 
 name: CD
 
@@ -86,6 +70,15 @@ on:
         required: false
         type: boolean
         default: true
+      require-approval:
+        description: >
+          Require manual approval before apply/deploy. When true, a standalone
+          job pauses the pipeline on a GitHub Environment named "approval"
+          (which must exist with required reviewers) right after the plan.
+          A single gate then covers both terraform apply and the helm deploy.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   git-diff-url:
@@ -137,40 +130,6 @@ jobs:
       message: "📋 New <${{ needs.git-diff-url.outputs.compare_url }}|changelog> for ${{ github.event.repository.name }} ${{ needs.git-diff-url.outputs.short_sha }} in ${{ inputs.environment }}"
     secrets: inherit
 
-  cancel-superseded:
-    name: Cancel Superseded Runs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel older runs waiting at this environment's approval gate
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Cancels older runs of the same caller workflow + branch that are
-        # waiting for approval into THIS call's environment (resolved via the
-        # pending_deployments API). Runs waiting at other environments' gates
-        # are left for the cd.yml call for that environment to sweep; runs
-        # queued "pending" behind a concurrency group are left to GitHub's
-        # native one-pending-per-group dedup. Never fails the pipeline:
-        # without `actions: write` from the caller it only logs a warning.
-        run: |
-          WORKFLOW_ID=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .workflow_id) || {
-            echo "::warning::Could not resolve workflow id; skipping supersede sweep"
-            exit 0
-          }
-          { gh api "repos/${{ github.repository }}/actions/workflows/${WORKFLOW_ID}/runs?branch=${{ github.ref_name }}&status=waiting&per_page=100" \
-              --jq ".workflow_runs[] | select(.run_number < ${{ github.run_number }}) | .id" || true
-          } | while read -r RUN_ID; do
-            [ -z "$RUN_ID" ] && continue
-            GATE_ENVS=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/pending_deployments" \
-              --jq '[.[].environment.name] | join(",")') || continue
-            if echo ",${GATE_ENVS}," | grep -q ",${{ inputs.environment }},"; then
-              echo "Cancelling run ${RUN_ID}: waiting for '${{ inputs.environment }}' approval, superseded by run #${{ github.run_number }}"
-              gh api -X POST "repos/${{ github.repository }}/actions/runs/${RUN_ID}/cancel" \
-                || echo "::warning::Could not cancel run ${RUN_ID} -- does the caller grant 'actions: write'?"
-            else
-              echo "Leaving run ${RUN_ID}: waiting for '${GATE_ENVS}', not '${{ inputs.environment }}'"
-            fi
-          done
-
   tf-plan:
     name: Terraform Plan
     # Plan is read-only (runs with -lock=false), so a newer push may freely
@@ -183,9 +142,34 @@ jobs:
       environment: ${{ inputs.environment }}
     secrets: inherit
 
+  approve:
+    name: Approve ${{ inputs.environment }}
+    needs: [tf-plan]
+    # Opt-in gate. When require-approval is false this job is skipped and every
+    # downstream `if` below treats 'skipped' as "proceed".
+    if: ${{ inputs.require-approval }}
+    runs-on: ubuntu-latest
+    # Pauses on the "approval" GitHub Environment (required reviewers live
+    # there). This job does nothing but wait, so cancel-in-progress can safely
+    # supersede an older run still parked here (see concurrency note at top).
+    environment: approval
+    concurrency:
+      group: cd-approve-${{ inputs.environment }}-${{ github.repository }}
+      cancel-in-progress: true
+    steps:
+      - name: Approved
+        run: echo "Deployment of ${{ inputs.image }} to ${{ inputs.environment }} approved"
+
   tf-apply:
     name: Terraform Apply
-    needs: [tf-plan]
+    needs: [tf-plan, approve]
+    # Run once the plan succeeded and approval passed (or was not required, i.e.
+    # the approve job was skipped). A declined or superseded approval leaves
+    # approve in 'failure'/'cancelled', which stops the pipeline here.
+    if: >
+      always() && !cancelled()
+      && needs.tf-plan.result == 'success'
+      && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
     # Own group, distinct from deploy below (see concurrency note at top of file).
     concurrency:
       group: cd-tf-apply-${{ inputs.environment }}-${{ github.repository }}
@@ -198,9 +182,14 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [tf-apply]
-    # Terraform apply is skipped on empty plan. This if ensures that job is run even if previous step is skipped
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    needs: [tf-apply, approve]
+    # Terraform apply is skipped on an empty plan, so tolerate a skipped apply.
+    # Proceed only if approval passed (or was not required) and nothing failed.
+    if: >
+      always() && !cancelled()
+      && !contains(needs.*.result, 'failure')
+      && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
+      && (needs.tf-apply.result == 'success' || needs.tf-apply.result == 'skipped')
     # Own group, distinct from tf-apply (see concurrency note at top of file).
     # Serializes deploys for the same environment across runs.
     concurrency:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       deployments: read
+      contents: read
     outputs:
       compare_url: ${{ steps.compare.outputs.compare_url }}
       slack_message: ${{ steps.compare.outputs.slack_message }}
@@ -85,7 +86,16 @@ jobs:
             *)   EMOJI=":clipboard:" ;;
           esac
 
-          MESSAGE="$EMOJI New <$URL|changelog> for $REPO_NAME ${GITHUB_SHA::7}."
+          COMMIT=$(gh api "repos/${{ github.repository }}/commits/${GITHUB_SHA}" 2>/dev/null || echo '{}')
+          AUTHOR=$(printf '%s' "$COMMIT" | jq -r '.author.login // .commit.author.name // "unknown"')
+          SUBJECT=$(printf '%s' "$COMMIT" | jq -r '.commit.message // ""' | head -n1 | tr -d '`<>')
+          EXCERPT=$(printf '%s' "$SUBJECT" | cut -c1-15 | sed 's/[[:space:]]*$//')
+          [ "${#SUBJECT}" -gt 15 ] && EXCERPT="$EXCERPT..."
+          DESC="$AUTHOR"
+          [ -n "$EXCERPT" ] && DESC="$AUTHOR ($EXCERPT)"
+
+          BT='`'
+          MESSAGE="$EMOJI New <$URL|changelog> for ${BT}${REPO_NAME}${BT} $DESC."
           if [ "$REQUIRE_APPROVAL" = "true" ]; then
             MESSAGE="$MESSAGE <$RUN_URL|Approve deployment>"
           fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -102,11 +102,12 @@ jobs:
     secrets: inherit
 
   # needs tf-plan so the changelog + approve link post right before the gate.
+  # @v3 exposes message_ts.
   notify-diff:
     name: Notify Git Diff
     needs: [git-diff-url, tf-plan]
     if: ${{ inputs.notify-changelog && needs.git-diff-url.outputs.compare_url != '' }}
-    uses: entur/gha-slack/.github/workflows/post.yml@v2
+    uses: entur/gha-slack/.github/workflows/post.yml@v3
     with:
       channel_id: ${{ inputs.channel-id }}
       message: ${{ needs.git-diff-url.outputs.slack_message }}
@@ -122,6 +123,17 @@ jobs:
     steps:
       - name: Approved
         run: echo "Deployment of ${{ inputs.image }} to ${{ inputs.environment }} approved"
+
+  # React on the changelog message once approved.
+  notify-approved:
+    needs: [notify-diff, approve]
+    if: ${{ needs.approve.result == 'success' && needs.notify-diff.outputs.message_ts != '' }}
+    uses: entur/gha-slack/.github/workflows/react.yml@v3
+    with:
+      channel_id: ${{ inputs.channel-id }}
+      message_ts: ${{ needs.notify-diff.outputs.message_ts }}
+      emoji: white_check_mark
+    secrets: inherit
 
   tf-apply:
     name: Terraform Apply

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,8 +9,9 @@
 #   tst/prd environments, buys two things:
 #     - one gate covers BOTH terraform apply and the helm deploy, so there is
 #       no more double approval, and
-#     - the wait happens in a job that does nothing else, which is what makes
-#       superseding safe (see the approve concurrency note below).
+#     - the wait happens in a job that does nothing else and holds no
+#       concurrency group, so a waiting run never blocks a newer run (see the
+#       approve concurrency note below).
 #   Callers that opt in should move required reviewers OFF the tst/prd
 #   environments and ONTO "approval"; otherwise apply/deploy gate a second time.
 #   When require-approval is false (the default) the job is skipped and the
@@ -20,19 +21,18 @@
 #   - tf-plan:  cancel-in-progress=true. The plan is read-only (runs with
 #               -lock=false), so a newer push may freely cancel an in-flight
 #               plan from an older commit.
-#   - approve:  cancel-in-progress=true. This is what supersedes stale runs: a
-#               job parked at the approval gate can be cancelled safely because
-#               it only waits -- it mutates nothing. So when a newer run reaches
-#               the gate, GitHub-native concurrency cancels the older run still
-#               parked there, and that run's apply/deploy never fire. A newer
-#               run is therefore never blocked by an older one waiting for
-#               approval -- the whole problem this pipeline sets out to solve.
-#               (This replaces an earlier pending_deployments "cancel-superseded"
-#               sweep and its need for the caller to grant `actions: write`.)
-#               cancel-in-progress could NOT be used while the gate lived inside
-#               apply/deploy, because there it cannot tell "waiting at the gate"
-#               (safe to cancel) from "terraform apply is executing" (must not
-#               be interrupted). Isolating the gate removes that ambiguity.
+#   - approve:  no concurrency group at all. The gate is a standalone job that
+#               only waits, so several runs may sit at it at once -- none
+#               cancels another, and because the job holds no group, none blocks
+#               a newer run's plan, apply or deploy either. So a newer commit
+#               always flows to its OWN gate and can be approved and deployed
+#               regardless of older runs still parked at the gate -- the acute
+#               problem this pipeline sets out to solve. Nothing is
+#               auto-superseded, though: approve the NEWEST waiting run and
+#               decline/cancel the older ones by hand (approving an older run
+#               would deploy an older image). This is also why the pipeline no
+#               longer needs the old pending_deployments "cancel-superseded"
+#               sweep or the caller's `actions: write`.
 #   - tf-apply: cancel-in-progress=false, in its own group. Serializes applies
 #               across runs; an apply that has started is never interrupted.
 #   - deploy:   cancel-in-progress=false, in its own group (distinct from
@@ -150,12 +150,12 @@ jobs:
     if: ${{ inputs.require-approval }}
     runs-on: ubuntu-latest
     # Pauses on the "approval" GitHub Environment (required reviewers live
-    # there). This job does nothing but wait, so cancel-in-progress can safely
-    # supersede an older run still parked here (see concurrency note at top).
+    # there). No concurrency group: the job only waits and holds nothing, so
+    # several runs may sit at the gate at once without cancelling or blocking
+    # each other or a newer run's apply/deploy. Nothing is auto-cancelled --
+    # approve the newest waiting run and decline/cancel older ones (see
+    # concurrency note at top of file).
     environment: approval
-    concurrency:
-      group: cd-approve-${{ inputs.environment }}-${{ github.repository }}
-      cancel-in-progress: true
     steps:
       - name: Approved
         run: echo "Deployment of ${{ inputs.image }} to ${{ inputs.environment }} approved"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,20 +37,27 @@
 # cancel-in-progress=true is no fix either: it cannot tell "waiting at the
 # gate" (safe to cancel) from "terraform apply is executing" (must not be
 # interrupted). So the cancel-superseded job, run at the start of every cd.yml
-# call, explicitly cancels OLDER runs of the same caller workflow + branch
-# whose run status is "waiting" or "pending" -- states in which no job is
-# executing, i.e. exactly the runs a human would cancel by hand. A run that is
-# actively applying/deploying is never touched; the concurrency groups still
-# serialize those.
+# call, cancels OLDER runs of the same caller workflow + branch that are
+# waiting for approval into THE SAME ENVIRONMENT as this call (resolved via
+# the pending_deployments API) -- exactly the run a human would cancel by hand
+# before approving the newest one. Runs waiting at OTHER environments' gates
+# are left alone; they are swept only when a newer run reaches that
+# environment (e.g. a run waiting at the prd gate survives until a newer run
+# has been approved all the way to its own prd stage). Runs that are merely
+# "pending" (queued behind a concurrency group) are also left alone: GitHub's
+# one-pending-per-group dedup already keeps only the newest queued run per
+# group, and the groups are per environment. A run that is actively
+# applying/deploying is never touched; the concurrency groups still serialize
+# those.
 #
 # Accepted gap: the sweep is a point-in-time check, so it misses a run that
 # enters "waiting" AFTER the sweep ran (e.g. an older run whose apply was
 # executing during the sweep and then parked at its deploy gate). Such a run
-# holds its group until the next push sweeps it away, or until someone
-# approves/cancels it manually -- rare, since it requires the older run to be
-# actively approved while the newer one is mid-stage. NOTE: the sweep requires
-# the CALLER to grant `actions: write` on the jobs that call cd.yml, otherwise
-# it logs a warning and does nothing.
+# holds its group until the next run entering that environment sweeps it, or
+# until someone approves/cancels it manually -- rare, since it requires the
+# older run to be actively approved while the newer one is mid-stage. NOTE:
+# the sweep requires the CALLER to grant `actions: write` on the jobs that
+# call cd.yml, otherwise it logs a warning and does nothing.
 
 name: CD
 
@@ -134,27 +141,34 @@ jobs:
     name: Cancel Superseded Runs
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel older runs stuck at approval gates
+      - name: Cancel older runs waiting at this environment's approval gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Cancels older runs of the same caller workflow + branch whose run
-        # status is "waiting" (parked at an environment approval gate) or
-        # "pending" (queued behind a concurrency group). In both states no
-        # job is executing, so cancelling is safe. Never fails the pipeline:
+        # Cancels older runs of the same caller workflow + branch that are
+        # waiting for approval into THIS call's environment (resolved via the
+        # pending_deployments API). Runs waiting at other environments' gates
+        # are left for the cd.yml call for that environment to sweep; runs
+        # queued "pending" behind a concurrency group are left to GitHub's
+        # native one-pending-per-group dedup. Never fails the pipeline:
         # without `actions: write` from the caller it only logs a warning.
         run: |
           WORKFLOW_ID=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .workflow_id) || {
             echo "::warning::Could not resolve workflow id; skipping supersede sweep"
             exit 0
           }
-          for STATUS in waiting pending; do
-            gh api "repos/${{ github.repository }}/actions/workflows/${WORKFLOW_ID}/runs?branch=${{ github.ref_name }}&status=${STATUS}&per_page=100" \
+          { gh api "repos/${{ github.repository }}/actions/workflows/${WORKFLOW_ID}/runs?branch=${{ github.ref_name }}&status=waiting&per_page=100" \
               --jq ".workflow_runs[] | select(.run_number < ${{ github.run_number }}) | .id" || true
-          done | sort -u | while read -r RUN_ID; do
+          } | while read -r RUN_ID; do
             [ -z "$RUN_ID" ] && continue
-            echo "Cancelling superseded run ${RUN_ID} (superseded by run #${{ github.run_number }})"
-            gh api -X POST "repos/${{ github.repository }}/actions/runs/${RUN_ID}/cancel" \
-              || echo "::warning::Could not cancel run ${RUN_ID} -- does the caller grant 'actions: write'?"
+            GATE_ENVS=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/pending_deployments" \
+              --jq '[.[].environment.name] | join(",")') || continue
+            if echo ",${GATE_ENVS}," | grep -q ",${{ inputs.environment }},"; then
+              echo "Cancelling run ${RUN_ID}: waiting for '${{ inputs.environment }}' approval, superseded by run #${{ github.run_number }}"
+              gh api -X POST "repos/${{ github.repository }}/actions/runs/${RUN_ID}/cancel" \
+                || echo "::warning::Could not cancel run ${RUN_ID} -- does the caller grant 'actions: write'?"
+            else
+              echo "Leaving run ${RUN_ID}: waiting for '${GATE_ENVS}', not '${{ inputs.environment }}'"
+            fi
           done
 
   tf-plan:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,47 +1,24 @@
 # CD pipeline for one environment: terraform plan -> [approval] -> apply -> deploy.
 #
-# Approval gate (opt-in via the require-approval input):
-#   When require-approval is true, a standalone `approve` job pauses the
-#   pipeline on a GitHub Environment named "approval" (which the caller repo
-#   must create, with required reviewers) immediately after the plan -- so a
-#   reviewer can read the plan before anything is applied or deployed. Putting
-#   the gate in its OWN job, instead of relying on required reviewers on the
-#   tst/prd environments, buys two things:
-#     - one gate covers BOTH terraform apply and the helm deploy, so there is
-#       no more double approval, and
-#     - the wait happens in a job that does nothing else and holds no
-#       concurrency group, so a waiting run never blocks a newer run (see the
-#       approve concurrency note below).
-#   Callers that opt in should move required reviewers OFF the tst/prd
-#   environments and ONTO "approval"; otherwise apply/deploy gate a second time.
-#   When require-approval is false (the default) the job is skipped and the
-#   pipeline flows straight through -- unchanged for existing callers.
+# Approval gate (opt-in via require-approval, default false): a standalone
+# `approve` job pauses after the plan on a per-environment "approval-<env>"
+# GitHub Environment (e.g. approval-prd) whose required reviewers gate the run,
+# so the target is clear in the approval dialog and notifications. One gate
+# covers both apply and deploy -- move required reviewers OFF tst/prd and ONTO
+# the matching approval-<env> so they don't gate twice. When false the job is
+# skipped and the pipeline flows straight through.
 #
-# Concurrency model (every group scoped per environment + repository):
-#   - tf-plan:  cancel-in-progress=true. The plan is read-only (runs with
-#               -lock=false), so a newer push may freely cancel an in-flight
-#               plan from an older commit.
-#   - approve:  no concurrency group at all. The gate is a standalone job that
-#               only waits, so several runs may sit at it at once -- none
-#               cancels another, and because the job holds no group, none blocks
-#               a newer run's plan, apply or deploy either. So a newer commit
-#               always flows to its OWN gate and can be approved and deployed
-#               regardless of older runs still parked at the gate -- the acute
-#               problem this pipeline sets out to solve. Nothing is
-#               auto-superseded, though: approve the NEWEST waiting run and
-#               decline/cancel the older ones by hand (approving an older run
-#               would deploy an older image). This is also why the pipeline no
-#               longer needs the old pending_deployments "cancel-superseded"
-#               sweep or the caller's `actions: write`.
-#   - tf-apply: cancel-in-progress=false, in its own group. Serializes applies
-#               across runs; an apply that has started is never interrupted.
-#   - deploy:   cancel-in-progress=false, in its own group (distinct from
-#               apply). Serializes deploys across runs.
-#
-# Accepted trade-off ("latest approved commit wins"): apply and deploy are not
-# strictly atomic across runs. Once approved, a run may finish its apply and
-# then lose the deploy group to another approved run; the newest approved
-# deploy wins, which is the intended outcome.
+# Concurrency (per environment + repository):
+#   - tf-plan:  cancel-in-progress=true -- read-only, so a newer push may cancel
+#               an in-flight plan.
+#   - approve:  no group -- it only waits, so runs may queue here without
+#               cancelling or blocking each other or newer runs. Nothing is
+#               auto-superseded: approve the NEWEST and cancel older ones by hand
+#               (approving an older run deploys an older image).
+#   - tf-apply / deploy: cancel-in-progress=false in separate groups -- these
+#               serialize across runs and a started apply/deploy is never
+#               interrupted. Not atomic across runs; the newest approved deploy
+#               wins.
 
 name: CD
 
@@ -73,9 +50,10 @@ on:
       require-approval:
         description: >
           Require manual approval before apply/deploy. When true, a standalone
-          job pauses the pipeline on a GitHub Environment named "approval"
-          (which must exist with required reviewers) right after the plan.
-          A single gate then covers both terraform apply and the helm deploy.
+          job pauses the pipeline on a per-environment GitHub Environment named
+          "approval-<environment>" (e.g. approval-prd; must exist with required
+          reviewers) right after the plan, so the approval dialog names the exact
+          target. A single gate then covers both terraform apply and helm deploy.
         required: false
         type: boolean
         default: false
@@ -143,19 +121,20 @@ jobs:
     secrets: inherit
 
   approve:
-    name: Approve ${{ inputs.environment }}
+    name: Approve deploy to ${{ inputs.environment }}
     needs: [tf-plan]
     # Opt-in gate. When require-approval is false this job is skipped and every
     # downstream `if` below treats 'skipped' as "proceed".
     if: ${{ inputs.require-approval }}
     runs-on: ubuntu-latest
-    # Pauses on the "approval" GitHub Environment (required reviewers live
-    # there). No concurrency group: the job only waits and holds nothing, so
-    # several runs may sit at the gate at once without cancelling or blocking
-    # each other or a newer run's apply/deploy. Nothing is auto-cancelled --
-    # approve the newest waiting run and decline/cancel older ones (see
-    # concurrency note at top of file).
-    environment: approval
+    # Pauses on a per-environment "approval-<env>" GitHub Environment (e.g.
+    # approval-prd), so the target is unambiguous in the approval dialog and in
+    # review notifications. Required reviewers live on that environment. No
+    # concurrency group: the job only waits and holds nothing, so several runs
+    # may sit at the gate at once without cancelling or blocking each other or a
+    # newer run's apply/deploy. Nothing is auto-cancelled -- approve the newest
+    # waiting run and decline/cancel older ones (see concurrency note at top).
+    environment: approval-${{ inputs.environment }}
     steps:
       - name: Approved
         run: echo "Deployment of ${{ inputs.image }} to ${{ inputs.environment }} approved"


### PR DESCRIPTION
Reworks `cd.yml`'s approval and notification model. Net change vs `main` is `cd.yml` only.

## Approval gate (opt-in)

- New **`require-approval`** input (default `false`). When `true`, a standalone `approve` job pauses the pipeline on a single **`approval`** GitHub Environment right after the terraform plan.
- One gate covers **both** `terraform apply` and the helm deploy — no more double approval. (Previously the gate lived *inside* the apply/deploy reusable workflows via required reviewers on the `tst`/`prd` environments.)
- The `approve` job holds **no concurrency group**, so a run waiting for approval never blocks a newer run — the newest commit always flows to its own gate. Nothing is auto-superseded: approve the newest waiting run and decline/cancel older ones.
- The job name is static (`Approve deployment`) because GitHub does not evaluate `${{ }}` in a job name while it waits at a gate; the target environment is shown by the caller job in the run graph and by the Slack message.

## Concurrency (per environment + repository)

- `tf-plan`: `cancel-in-progress: true` — read-only, so a newer push may cancel an in-flight plan.
- `tf-apply` / `deploy`: `cancel-in-progress: false` in separate groups — serialize across runs; a started apply/deploy is never interrupted.

## Slack notifications

- gha-helm's own deploy/approval Slack posts are turned off (the deploy job no longer passes `slack_channel_id`); `notify-diff` is the single notification.
- `notify-diff` now posts **right before the gate** (`needs: tf-plan`) and uses `gha-slack post.yml@v3` (which returns `message_ts`).
- New message format: per-environment emoji (`:dev:` / `:staging:` / `:prod:`), repo name in backticks (inline code), the commit **author** and a ~15-char **commit-subject excerpt**, plus an **Approve deployment** link when the run is gated. The git hash and `in <env>` are dropped. Example:
  > :staging: New `changelog` for `` `abt-referencedata` `` olereidar (trying out new...). `Approve deployment`
- New **`notify-approved`** job reacts ✅ (`gha-slack react.yml@v3`) on the changelog message once the deploy is approved. `react@v3` treats `already_reacted` as success, so job re-runs are safe.

## Permissions

- `git-diff-url` gains `contents: read` for the commit lookup. All current callers already grant it, and the lookup degrades gracefully (`|| echo '{}'` → author `unknown`) if a caller does not — not a breaking change.

## Caller migration

Opt in per environment by setting `require-approval: true` on the `cd.yml` call, then in repo settings:
- Create an **`approval`** environment with required reviewers.
- Remove required reviewers from the `tst`/`prd` environments (otherwise apply/deploy gate twice).

Consumer PRs: entur/abt-referencedata#3375, entur/abt-backoffice#3668, entur/abt-core#5064, entur/abt-kafka-publisher#362, entur/abt-offline-control#269, entur/abt-reporting#2069.