### PR TITLE
Make cd.yml channel-id input optional

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,9 +16,10 @@ on:
         required: true
         type: string
       channel-id:
-        description: Slack channel ID for deployment notifications
-        required: true
+        description: Slack channel ID for deployment notifications (only used when notify-changelog is true; leave unset to disable Slack)
+        required: false
         type: string
+        default: ""
       container-name:
         description: "Replace the image of a named container in the common.containers array. Resolves the array index automatically using the container name in values.yaml"
         required: false
@@ -116,7 +117,7 @@ jobs:
   notify-diff:
     name: Notify Git Diff
     needs: [git-diff-url, tf-plan]
-    if: ${{ inputs.notify-changelog && needs.git-diff-url.outputs.compare_url != '' }}
+    if: ${{ inputs.notify-changelog && inputs.channel-id != '' && needs.git-diff-url.outputs.compare_url != '' }}
     uses: entur/gha-slack/.github/workflows/post.yml@v3
     with:
       channel_id: ${{ inputs.channel-id }}


### PR DESCRIPTION
## What

Makes the `channel-id` input of `cd.yml` **optional** (`required: false`, default `""`).

`channel-id` is only consumed by the changelog Slack notification (`notify-diff`), which only fires when `notify-changelog: true`. Callers that post no Slack — e.g. the emergency-deploy workflows, which set `notify-changelog: false` — shouldn't have to supply a channel just to satisfy a required input.

## Changes

- `channel-id`: `required: true` → `required: false` with `default: ""`
- `notify-diff` guard hardened with `&& inputs.channel-id != ''`, so an empty channel-id can never post to Slack even if `notify-changelog` is true

## Backward compatibility

Fully backward compatible — existing callers that pass a `channel-id` (all the `deploy-main` pipelines) are unaffected.

## Follow-up (merge order)

Enables dropping `channel-id` from the emergency-deploy wrappers:
- entur/abt-referencedata#3395
- entur/abt-core#5096

⚠️ **This must be merged and the `v1` tag moved before those two wrapper PRs merge** — otherwise they'd omit a still-required input and fail.