### PR TITLE
Add reusable upload-file-to-bucket workflow (per-environment deploy SA)

### DIFF
--- a/.github/workflows/upload-file-to-bucket.yml
+++ b/.github/workflows/upload-file-to-bucket.yml
@@ -22,11 +22,6 @@ on:
         description: Object path within the bucket (e.g. "descriptors/abt-core-service-2.1132.pb.b64").
         required: true
         type: string
-      environment:
-        description: GitHub environment name passed to the cloud-auth action (identity comes from the CI vars).
-        required: false
-        type: string
-        default: dev
       overwrite:
         description: If false (default), skip the upload when the destination object already exists. Set true to always overwrite.
         required: false
@@ -62,7 +57,8 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: entur/gha-meta/.github/actions/cloud-auth@v1
         with:
-          environment: ${{ inputs.environment }}
+          # Required by cloud-auth but unused for GCP; identity comes from the CI vars below.
+          environment: dev
           cloud_provider: gcp
           gcp_workload_identity_provider: ${{ vars.CI_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.CI_SERVICE_ACCOUNT }}

--- a/.github/workflows/upload-file-to-bucket.yml
+++ b/.github/workflows/upload-file-to-bucket.yml
@@ -1,0 +1,84 @@
+# Reusable workflow: downloads a caller-uploaded artifact and copies one file to a GCS bucket.
+# Auth uses the caller repo's CI_WORKLOAD_IDENTITY_PROVIDER / CI_SERVICE_ACCOUNT vars.
+
+name: Upload File To Bucket
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: Name of the artifact (uploaded by the caller) that contains the file to upload.
+        required: true
+        type: string
+      source-file:
+        description: Path of the file to upload, relative to the root of the downloaded artifact.
+        required: true
+        type: string
+      bucket:
+        description: Target GCS bucket name, without the gs:// prefix (e.g. "ent-gcs-tfa-abtcore").
+        required: true
+        type: string
+      destination:
+        description: Object path within the bucket (e.g. "descriptors/abt-core-service-2.1132.pb.b64").
+        required: true
+        type: string
+      environment:
+        description: GitHub environment name passed to the cloud-auth action (identity comes from the CI vars).
+        required: false
+        type: string
+        default: dev
+      overwrite:
+        description: If false (default), skip the upload when the destination object already exists. Set true to always overwrite.
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  upload:
+    name: Upload to bucket
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: artifact
+
+      - name: Verify source file exists
+        shell: bash
+        env:
+          SOURCE_FILE: ${{ inputs.source-file }}
+        run: |
+          if [ ! -f "artifact/${SOURCE_FILE}" ]; then
+            echo "::error::Source file 'artifact/${SOURCE_FILE}' not found in artifact '${{ inputs.artifact-name }}'."
+            echo "Contents of the downloaded artifact:"
+            find artifact -type f || true
+            exit 1
+          fi
+
+      - name: Authenticate with Google Cloud
+        uses: entur/gha-meta/.github/actions/cloud-auth@v1
+        with:
+          environment: ${{ inputs.environment }}
+          cloud_provider: gcp
+          gcp_workload_identity_provider: ${{ vars.CI_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: ${{ vars.CI_SERVICE_ACCOUNT }}
+
+      - name: Upload to bucket
+        shell: bash
+        env:
+          SOURCE_FILE: ${{ inputs.source-file }}
+          BUCKET: ${{ inputs.bucket }}
+          DESTINATION: ${{ inputs.destination }}
+          OVERWRITE: ${{ inputs.overwrite }}
+        run: |
+          TARGET="gs://${BUCKET}/${DESTINATION}"
+          if [ "${OVERWRITE}" != "true" ] && gcloud storage objects describe "${TARGET}" >/dev/null 2>&1; then
+            echo ":information_source: Object ${TARGET} already exists and overwrite=false — skipping upload." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          gcloud storage cp "artifact/${SOURCE_FILE}" "${TARGET}"
+          echo ":white_check_mark: Uploaded \`${SOURCE_FILE}\` to \`${TARGET}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/upload-file-to-bucket.yml
+++ b/.github/workflows/upload-file-to-bucket.yml
@@ -75,6 +75,8 @@ jobs:
           DESTINATION: ${{ inputs.destination }}
           OVERWRITE: ${{ inputs.overwrite }}
         run: |
+          : "${BUCKET:?bucket input is empty, check the caller variable}"
+          : "${DESTINATION:?destination input is empty}"
           TARGET="gs://${BUCKET}/${DESTINATION}"
           if [ "${OVERWRITE}" != "true" ] && gcloud storage objects describe "${TARGET}" >/dev/null 2>&1; then
             echo ":information_source: Object ${TARGET} already exists and overwrite=false — skipping upload." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/upload-file-to-bucket.yml
+++ b/.github/workflows/upload-file-to-bucket.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      set-custom-time:
+        description: Stamp the uploaded object with a Custom-Time of the upload moment, so a bucket lifecycle rule keyed on days_since_custom_time can expire it.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   upload:
@@ -76,6 +81,7 @@ jobs:
           BUCKET: ${{ inputs.bucket }}
           DESTINATION: ${{ inputs.destination }}
           OVERWRITE: ${{ inputs.overwrite }}
+          SET_CUSTOM_TIME: ${{ inputs.set-custom-time }}
         run: |
           : "${BUCKET:?bucket input is empty, check the caller variable}"
           : "${DESTINATION:?destination input is empty}"
@@ -84,5 +90,9 @@ jobs:
             echo ":information_source: Object ${TARGET} already exists and overwrite=false — skipping upload." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          gcloud storage cp "artifact/${SOURCE_FILE}" "${TARGET}"
+          CP_ARGS=()
+          if [ "${SET_CUSTOM_TIME}" = "true" ]; then
+            CP_ARGS+=(--custom-time="$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+          fi
+          gcloud storage cp "${CP_ARGS[@]}" "artifact/${SOURCE_FILE}" "${TARGET}"
           echo ":white_check_mark: Uploaded \`${SOURCE_FILE}\` to \`${TARGET}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/upload-file-to-bucket.yml
+++ b/.github/workflows/upload-file-to-bucket.yml
@@ -1,5 +1,7 @@
 # Reusable workflow: downloads a caller-uploaded artifact and copies one file to a GCS bucket.
-# Auth uses the caller repo's CI_WORKLOAD_IDENTITY_PROVIDER / CI_SERVICE_ACCOUNT vars.
+# Runs in the caller's `environment` and authenticates as that environment's deploy service account
+# (vars.SERVICE_ACCOUNT / vars.WORKLOAD_IDENTITY_PROVIDER), so it can write to buckets in the app
+# project — e.g. a descriptor an environment's Terraform apply later reads back as the same SA.
 
 name: Upload File To Bucket
 
@@ -15,11 +17,15 @@ on:
         required: true
         type: string
       bucket:
-        description: Target GCS bucket name, without the gs:// prefix (e.g. "ent-gcs-tfa-abtcore").
+        description: Target GCS bucket name, without the gs:// prefix (e.g. "ent-gcs-abtcore-dev-001").
         required: true
         type: string
       destination:
         description: Object path within the bucket (e.g. "descriptors/abt-core-service-2.1132.pb.b64").
+        required: true
+        type: string
+      environment:
+        description: GitHub environment to run in; the job authenticates as this environment's deploy service account (vars.SERVICE_ACCOUNT).
         required: true
         type: string
       overwrite:
@@ -32,6 +38,7 @@ jobs:
   upload:
     name: Upload to bucket
     runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
       id-token: write
@@ -57,11 +64,10 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: entur/gha-meta/.github/actions/cloud-auth@v1
         with:
-          # Required by cloud-auth but unused for GCP; identity comes from the CI vars below.
-          environment: dev
+          environment: ${{ inputs.environment }}
           cloud_provider: gcp
-          gcp_workload_identity_provider: ${{ vars.CI_WORKLOAD_IDENTITY_PROVIDER }}
-          gcp_service_account: ${{ vars.CI_SERVICE_ACCOUNT }}
+          gcp_workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: ${{ vars.SERVICE_ACCOUNT }}
 
       - name: Upload to bucket
         shell: bash


### PR DESCRIPTION
Reusable workflow that downloads a caller-uploaded artifact and copies one file to a GCS bucket.

## Identity

Runs in the caller-supplied `environment` and authenticates as that environment's **deploy service account** (`vars.SERVICE_ACCOUNT` / `vars.WORKLOAD_IDENTITY_PROVIDER`) — the same identity `gha-terraform` apply uses. This lets a caller publish a file to a bucket in its **app project** (where the deploy SA is Storage Admin) that the same environment's Terraform apply later reads back as the same identity.

An earlier revision authenticated as the CI SA, which only reaches the shared Terraform state bucket. That doesn't work when the object must be read at apply time: apply re-plans as the environment deploy SA, which has no object-read access in the state bucket (it lives in a central project, and the deploy SAs only get state access there). See entur/abt-referencedata#3473 for the full diagnosis.

## Inputs

| input | required | description |
|-------|----------|-------------|
| `artifact-name` | yes | Artifact (uploaded by the caller) that contains the file. |
| `source-file` | yes | Path of the file within the downloaded artifact. |
| `bucket` | yes | Target GCS bucket, without `gs://` (e.g. `ent-gcs-abtcore-dev-001`). |
| `destination` | yes | Object path within the bucket. |
| `environment` | yes | GitHub environment to run in / whose deploy SA to authenticate as. |
| `overwrite` | no (default false) | Overwrite the destination object if it already exists. |
| `set-custom-time` | no (default false) | Stamp the object with a Custom-Time of the upload moment, so a bucket lifecycle rule keyed on `days_since_custom_time` can expire it. |

## Usage

```yaml
jobs:
  upload-descriptor-dev:
    needs: generate-endpoints-descriptor
    uses: entur/abt-gha-public/.github/workflows/upload-file-to-bucket.yml@<ref>
    permissions:
      contents: read
      id-token: write
    with:
      environment: dev
      artifact-name: endpoints-descriptor
      source-file: abt-core-service-${{ needs.generate-endpoints-descriptor.outputs.version }}.pb.b64
      bucket: ent-gcs-abtcore-dev-001
      destination: descriptors/abt-core-service-${{ needs.generate-endpoints-descriptor.outputs.version }}.pb.b64
      set-custom-time: true   # pair with a days_since_custom_time lifecycle rule to auto-expire
    secrets: inherit
```

Call once per environment (dev/tst/prd), gated into your promotion chain.

First consumer: entur/abt-referencedata#3473. Also needed by abt-core.